### PR TITLE
lrpc-60 Write_unchecked<etl::string<T>> does not write trailing null …

### DIFF
--- a/resources/cpp/include/lrpc/EtlRwExtensions.hpp
+++ b/resources/cpp/include/lrpc/EtlRwExtensions.hpp
@@ -276,10 +276,18 @@ namespace lrpc
     template <typename T, typename etl::enable_if<is_etl_string<T>::value, bool>::type = true>
     void write_unchecked(etl::byte_stream_writer &stream, const T& value)
     {
-        for (auto c : value)
+        for (const auto c : value)
         {
             stream.write_unchecked<char>(c);
         }
+
+        // fill remainder with null terminators
+        for (auto i = value.size(); i < value.capacity(); ++i)
+        {
+            stream.write_unchecked<char>('\0');
+        }
+
+        // final null terminator
         stream.write_unchecked<char>('\0');
     };
 

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -229,18 +229,20 @@ TEST(TestEtlRwExtensions, writeString)
     etl::array<uint8_t, 10> storage;
     etl::byte_stream_writer writer(storage.begin(), storage.end(), etl::endian::little);
 
-    lrpc::write_unchecked<etl::string<2>>(writer, "T1");
+    lrpc::write_unchecked<etl::string<4>>(writer, "T1");
     etl::string<2> t2("T2");
     lrpc::write_unchecked<etl::string<2>>(writer, t2);
 
     auto written = writer.used_data();
-    ASSERT_EQ(6, written.size());
+    ASSERT_EQ(8, written.size());
     EXPECT_EQ('T', written[0]);
     EXPECT_EQ('1', written[1]);
     EXPECT_EQ('\0', written[2]);
-    EXPECT_EQ('T', written[3]);
-    EXPECT_EQ('2', written[4]);
-    EXPECT_EQ('\0', written[5]);
+    EXPECT_EQ('\0', written[3]);
+    EXPECT_EQ('\0', written[4]);
+    EXPECT_EQ('T', written[5]);
+    EXPECT_EQ('2', written[6]);
+    EXPECT_EQ('\0', written[7]);
 }
 
 TEST(TestEtlRwExtensions, writeArray)

--- a/tests/cpp/TestServer1.cpp
+++ b/tests/cpp/TestServer1.cpp
@@ -41,7 +41,7 @@ public:
     MOCK_METHOD(uint16_t, f13, (), (override));
     MOCK_METHOD(float, f14, (), (override));
     MOCK_METHOD((etl::array<uint16_t, 2>), f15, (), (override));
-    MOCK_METHOD(etl::string<20>, f16, (), (override));
+    MOCK_METHOD(etl::string<8>, f16, (), (override));
     MOCK_METHOD(ts1::CompositeData, f17, (), (override));
     MOCK_METHOD(ts1::MyEnum, f18, (), (override));
     MOCK_METHOD((etl::array<ts1::CompositeData2, 2>), f19, (), (override));
@@ -220,9 +220,9 @@ TEST_F(TestServer1, decodeF15)
 // Decode function f16 which returns a string
 TEST_F(TestServer1, decodeF16)
 {
-    EXPECT_CALL(s0Service, f16()).WillOnce(Return(etl::string<20>("Test")));
+    EXPECT_CALL(s0Service, f16()).WillOnce(Return(etl::string<8>("Test")));
     auto response = receive({16});
-    EXPECT_RESPONSE({16, 'T', 'e', 's', 't', '\0'}, response);
+    EXPECT_RESPONSE({16, 'T', 'e', 's', 't', '\0', '\0', '\0', '\0', '\0'}, response);
 }
 
 // Decode function f17 which returns custom type

--- a/tests/testdata/TestServer1.lrpc.yaml
+++ b/tests/testdata/TestServer1.lrpc.yaml
@@ -62,7 +62,7 @@ services:
       - name: "f16"
         returns:
           - name: "a"
-            type: string_20
+            type: string_8
       - name: "f17"
         returns:
           - name: "cd"


### PR DESCRIPTION
…characters

* Write trailing null characters
* Update and improve tests