### PR TITLE
LRPC-93 LRPCC fail on unregistered service

### DIFF
--- a/src/lrpc/client/lrpc_client.py
+++ b/src/lrpc/client/lrpc_client.py
@@ -37,9 +37,15 @@ class LrpcClient:
         return LrpcClient.IncompleteResponse()
 
     def decode(self, encoded: bytes) -> Union[dict[str, Any], VoidResponse]:
+        if len(encoded) < 3:
+            raise ValueError(f"Unable to decode message from {encoded!r}: an LRPC message has at least 3 bytes")
+
         # skip packet length at index 0
         service_id = encoded[1]
         function_id = encoded[2]
+
+        if (service_id == 255) and (function_id == 0):
+            raise ValueError("The LRPC server reported an error")
 
         service = self.lrpc_def.service_by_id(service_id)
         if not service:

--- a/src/lrpc/codegen/service_shim.py
+++ b/src/lrpc/codegen/service_shim.py
@@ -77,13 +77,17 @@ class ServiceShimVisitor(LrpcVisitor):
             self.__file.label("public")
             self.__file(f"virtual ~{self.__service_name}ServiceShim() = default;")
             self.__file.newline()
-            self.__file(f"uint32_t id() const override {{ return {self.__service_id}; }}")
+            self.__file(f"uint8_t id() const override {{ return {self.__service_id}; }}")
             self.__file.newline()
 
-            with self.__file.block("void invoke(Reader &reader, Writer &writer) override"):
+            with self.__file.block("bool invoke(Reader &reader, Writer &writer) override"):
                 self.__file("auto functionId = reader.read_unchecked<uint8_t>();")
+                with self.__file.block(f"if (shim(functionId) == &{self.__service_name}ServiceShim::null_shim)"):
+                    self.__file("return false;")
+                self.__file("writer.write_unchecked<uint8_t>(id());")
                 self.__file("writer.write_unchecked<uint8_t>(functionId);")
                 self.__file("((this)->*(shim(functionId)))(reader, writer);")
+                self.__file("return true;")
 
             self.__file.newline()
             self.__file.label("protected")
@@ -104,10 +108,9 @@ class ServiceShimVisitor(LrpcVisitor):
 
     def __write_shim_array(self) -> None:
         null_shim_name = "null"
-        self.__file.write(f"using ShimType =  void ({self.__service_name}ServiceShim::*)(Reader &, Writer &);")
-        if self.__max_function_id != (self.__number_functions - 1):
-            self.__file.write(f"constexpr void {null_shim_name}_shim(Reader&, Writer&) {{}}")
-            self.__file.newline()
+        self.__file.write(f"using ShimType = void ({self.__service_name}ServiceShim::*)(Reader &, Writer &);")
+        self.__file.write(f"constexpr void {null_shim_name}_shim(Reader&, Writer&) {{}}")
+        self.__file.newline()
 
         with self.__file.block("static ShimType shim(const size_t functionId)"):
             with self.__file.block(f"static constexpr etl::array<ShimType, {self.__max_function_id + 1}> shims", ";"):
@@ -117,7 +120,14 @@ class ServiceShimVisitor(LrpcVisitor):
                         self.__file(f"&{self.__service_name}ServiceShim::{name}_shim,")
 
             self.__file.newline()
+
+            with self.__file.block("if (functionId > shims.size())"):
+                self.__file.write(f"return &{self.__service_name}ServiceShim::null_shim;")
+
+            self.__file.newline()
+
             self.__file.write("return shims.at(functionId);")
+
 
     def __function_shim_body(self) -> list[str]:
         body = []

--- a/src/lrpc/codegen/service_shim.py
+++ b/src/lrpc/codegen/service_shim.py
@@ -24,7 +24,6 @@ class ServiceShimVisitor(LrpcVisitor):
         self.__function_name: str
         self.__service_name: str
         self.__service_id: int
-        self.__number_functions = 0
 
     def visit_lrpc_def(self, lrpc_def: LrpcDef) -> None:
         self.__namespace = lrpc_def.namespace()
@@ -37,7 +36,6 @@ class ServiceShimVisitor(LrpcVisitor):
         self.__function_shims = []
         self.__service_name = service.name()
         self.__service_id = service.id()
-        self.__number_functions = len(service.functions())
 
         write_file_banner(self.__file)
         self.__write_include_guard()

--- a/src/lrpc/resources/cpp/Server.hpp
+++ b/src/lrpc/resources/cpp/Server.hpp
@@ -1,4 +1,3 @@
-// This file has been generated with LRPC version 0.9.4.dev0
 #pragma once
 #include "Service.hpp"
 #include <etl/array.h>

--- a/src/lrpc/resources/cpp/Service.hpp
+++ b/src/lrpc/resources/cpp/Service.hpp
@@ -12,8 +12,8 @@ public:
     using Reader = etl::byte_stream_reader;
     using Writer = etl::byte_stream_writer;
 
-    virtual uint32_t id() const = 0;
-    virtual void invoke(Reader &reader, Writer &writer) = 0;
+    virtual uint8_t id() const = 0;
+    virtual bool invoke(Reader &reader, Writer &writer) = 0;
 };
 
 }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(BUILD_GMOCK ON)
 set(gtest_force_shared_crt on)
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -24,8 +24,9 @@ add_custom_command(OUTPUT ${LRPC_IS_BUILT}
                   DEPENDS ${LRPC_PY_SRC_FILES})
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/generated/lrpccore/EtlRwExtensions.hpp
-                  COMMAND lrpcg cppcore -o ${CMAKE_CURRENT_SOURCE_DIR}/generated
-                  COMMENT "Generate LRPC server core")
+                  COMMENT "Generate LRPC server core"
+                  DEPENDS ${LRPC_IS_BUILT}
+                  COMMAND lrpcg cppcore -o ${CMAKE_CURRENT_SOURCE_DIR}/generated)
 
 
 function(generate_lrpc server_name)
@@ -58,7 +59,8 @@ add_executable(UnitTests
                 ${CMAKE_CURRENT_SOURCE_DIR}/generated/Server2/Server2.hpp
                 ${CMAKE_CURRENT_SOURCE_DIR}/generated/Server3/Server3.hpp
                 ${CMAKE_CURRENT_SOURCE_DIR}/generated/Server4/Server4.hpp
-                ${CMAKE_CURRENT_SOURCE_DIR}/generated/lrpccore/EtlRwExtensions.hpp)
+                ${CMAKE_CURRENT_SOURCE_DIR}/generated/lrpccore/EtlRwExtensions.hpp
+                TestServerErrors.cpp)
 
 target_include_directories(UnitTests PRIVATE .)
 target_include_directories(UnitTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/generated)

--- a/tests/cpp/TestServer1.cpp
+++ b/tests/cpp/TestServer1.cpp
@@ -2,7 +2,8 @@
 #include "TestServerBase.hpp"
 
 using ::testing::Return;
-
+namespace
+{
 class Mockservice : public ts1::s0ServiceShim
 {
 public:
@@ -34,6 +35,7 @@ public:
     MOCK_METHOD((etl::optional<etl::string_view>), f25, (), (override));
     MOCK_METHOD((etl::array<etl::string_view, 3>), f26, (), (override));
 };
+}
 
 using TestServer1 = TestServerBase<Mockservice>;
 

--- a/tests/cpp/TestServer1.cpp
+++ b/tests/cpp/TestServer1.cpp
@@ -103,7 +103,7 @@ TEST_F(TestServer1, decodeF0)
     EXPECT_CALL(s0Service, f1()).Times(0);
 
     auto response = receive({0});
-    EXPECT_RESPONSE({0}, response);
+    EXPECT_RESPONSE({0, 0}, response);
 }
 
 // Decode void function f1. Make sure f0 is not called
@@ -113,7 +113,7 @@ TEST_F(TestServer1, decodeF1)
     EXPECT_CALL(s0Service, f1()).Times(1);
 
     auto response = receive({1});
-    EXPECT_RESPONSE({1}, response);
+    EXPECT_RESPONSE({0, 1}, response);
 }
 
 // Decode function f2 with uint8_t arg
@@ -121,7 +121,7 @@ TEST_F(TestServer1, decodeF2)
 {
     EXPECT_CALL(s0Service, f2(123));
     auto response = receive({2, 123});
-    EXPECT_RESPONSE({2}, response);
+    EXPECT_RESPONSE({0, 2}, response);
 }
 
 // Decode function f3 with uint16_t arg
@@ -129,7 +129,7 @@ TEST_F(TestServer1, decodeF3)
 {
     EXPECT_CALL(s0Service, f3(0xCDAB));
     auto response = receive({3, 0xAB, 0xCD});
-    EXPECT_RESPONSE({3}, response);
+    EXPECT_RESPONSE({0, 3}, response);
 }
 
 // Decode function f4 with float arg
@@ -137,7 +137,7 @@ TEST_F(TestServer1, decodeF4)
 {
     EXPECT_CALL(s0Service, f4(123.456F));
     auto response = receive({4, 0x79, 0xE9, 0xF6, 0x42});
-    EXPECT_RESPONSE({4}, response);
+    EXPECT_RESPONSE({0, 4}, response);
 }
 
 // Decode function f5 with array of uint16_t arg
@@ -146,7 +146,7 @@ TEST_F(TestServer1, decodeF5)
     std::vector<uint16_t> expected{0xBBAA, 0xDDCC};
     EXPECT_CALL(s0Service, f5(SPAN_EQ(expected)));
     auto response = receive({5, 0xAA, 0xBB, 0xCC, 0xDD});
-    EXPECT_RESPONSE({5}, response);
+    EXPECT_RESPONSE({0, 5}, response);
 }
 
 // Decode function f6 with string arg
@@ -154,7 +154,7 @@ TEST_F(TestServer1, decodeF6)
 {
     EXPECT_CALL(s0Service, f6(etl::string_view("Test")));
     auto response = receive({6, 'T', 'e', 's', 't', '\0'});
-    EXPECT_RESPONSE({6}, response);
+    EXPECT_RESPONSE({0, 6}, response);
 }
 
 // Decode function f6 with string arg and missing terminator
@@ -162,7 +162,7 @@ TEST_F(TestServer1, decodeF6WithMissingStringTerminator)
 {
     EXPECT_CALL(s0Service, f6(etl::string_view("Test")));
     auto response = receive({6, 'T', 'e', 's', 't'});
-    EXPECT_RESPONSE({6}, response);
+    EXPECT_RESPONSE({0, 6}, response);
 }
 
 // Decode function f7 with custom type
@@ -171,7 +171,7 @@ TEST_F(TestServer1, decodeF7)
     ts1::CompositeData expected{{0xBBAA, 0xDDCC}, 123, true};
     EXPECT_CALL(s0Service, f7(expected));
     auto response = receive({7, 0xAA, 0xBB, 0xCC, 0xDD, 123, 1});
-    EXPECT_RESPONSE({7}, response);
+    EXPECT_RESPONSE({0, 7}, response);
 }
 
 // Decode function f8 with custom enum
@@ -179,7 +179,7 @@ TEST_F(TestServer1, decodeF8)
 {
     EXPECT_CALL(s0Service, f8(ts1::MyEnum::V3));
     auto response = receive({8, 0x03});
-    EXPECT_RESPONSE({8}, response);
+    EXPECT_RESPONSE({0, 8}, response);
 }
 
 // Decode function f9 with array of custom type
@@ -190,7 +190,7 @@ TEST_F(TestServer1, decodeF9)
         ts1::CompositeData2{0xCC, 0xDD}};
     EXPECT_CALL(s0Service, f9(SPAN_EQ(expected)));
     auto response = receive({9, 0xAA, 0xBB, 0xCC, 0xDD});
-    EXPECT_RESPONSE({9}, response);
+    EXPECT_RESPONSE({0, 9}, response);
 }
 
 // Decode function f10 with nested custom types
@@ -199,7 +199,7 @@ TEST_F(TestServer1, decodeF10)
     ts1::CompositeData3 expected{{0xAA, 0xBB}, ts1::MyEnum::V1};
     EXPECT_CALL(s0Service, f10(expected));
     auto response = receive({10, 0xAA, 0xBB, 0x01});
-    EXPECT_RESPONSE({10}, response);
+    EXPECT_RESPONSE({0, 10}, response);
 }
 
 // Decode function f11 with two uint8_t args
@@ -207,7 +207,7 @@ TEST_F(TestServer1, decodef11)
 {
     EXPECT_CALL(s0Service, f11(123, 111));
     auto response = receive({11, 123, 111});
-    EXPECT_RESPONSE({11}, response);
+    EXPECT_RESPONSE({0, 11}, response);
 }
 
 // Decode function f12 which returns uint8_t
@@ -215,7 +215,7 @@ TEST_F(TestServer1, decodef12)
 {
     EXPECT_CALL(s0Service, f12()).WillOnce(Return(0xAB));
     auto response = receive({12});
-    EXPECT_RESPONSE({12, 0xAB}, response);
+    EXPECT_RESPONSE({0, 12, 0xAB}, response);
 }
 
 // Decode function f13 which returns uint16_t
@@ -223,7 +223,7 @@ TEST_F(TestServer1, decodef13)
 {
     EXPECT_CALL(s0Service, f13()).WillOnce(Return(0xABCD));
     auto response = receive({13});
-    EXPECT_RESPONSE({13, 0xCD, 0xAB}, response);
+    EXPECT_RESPONSE({0, 13, 0xCD, 0xAB}, response);
 }
 
 // Decode function f14 which returns float
@@ -231,7 +231,7 @@ TEST_F(TestServer1, decodeF14)
 {
     EXPECT_CALL(s0Service, f14()).WillOnce(Return(123.456));
     auto response = receive({14});
-    EXPECT_RESPONSE({14, 0x79, 0xE9, 0xF6, 0x42}, response);
+    EXPECT_RESPONSE({0, 14, 0x79, 0xE9, 0xF6, 0x42}, response);
 }
 
 // Decode function f15 which return array of uint16_t
@@ -240,7 +240,7 @@ TEST_F(TestServer1, decodeF15)
     etl::array<uint16_t, 2> expected{0xBBAA, 0xDDCC};
     EXPECT_CALL(s0Service, f15()).WillOnce(Return(expected));
     auto response = receive({15});
-    EXPECT_RESPONSE({15, 0xAA, 0xBB, 0xCC, 0xDD}, response);
+    EXPECT_RESPONSE({0, 15, 0xAA, 0xBB, 0xCC, 0xDD}, response);
 }
 
 // Decode function f16 which returns a string
@@ -248,7 +248,7 @@ TEST_F(TestServer1, decodeF16)
 {
     EXPECT_CALL(s0Service, f16()).WillOnce(Return(etl::string<8>("Test")));
     auto response = receive({16});
-    EXPECT_RESPONSE({16, 'T', 'e', 's', 't', '\0', '\0', '\0', '\0', '\0'}, response);
+    EXPECT_RESPONSE({0, 16, 'T', 'e', 's', 't', '\0', '\0', '\0', '\0', '\0'}, response);
 }
 
 // Decode function f17 which returns custom type
@@ -256,7 +256,7 @@ TEST_F(TestServer1, decodeF17)
 {
     EXPECT_CALL(s0Service, f17()).WillOnce(Return(ts1::CompositeData{{0xBBAA, 0xDDCC}, 123, true}));
     auto response = receive({17});
-    EXPECT_RESPONSE({17, 0xAA, 0xBB, 0xCC, 0xDD, 123, 1}, response);
+    EXPECT_RESPONSE({0, 17, 0xAA, 0xBB, 0xCC, 0xDD, 123, 1}, response);
 }
 
 // Decode function f18 which returns custom enum
@@ -264,7 +264,7 @@ TEST_F(TestServer1, decodeF18)
 {
     EXPECT_CALL(s0Service, f18()).WillOnce(Return(ts1::MyEnum::V3));
     auto response = receive({18});
-    EXPECT_RESPONSE({18, 0x03}, response);
+    EXPECT_RESPONSE({0, 18, 0x03}, response);
 }
 
 // Decode function f19 which returns array of custom type
@@ -275,7 +275,7 @@ TEST_F(TestServer1, decodeF19)
         ts1::CompositeData2{0xCC, 0xDD}};
     EXPECT_CALL(s0Service, f19()).WillOnce(Return(expected));
     auto response = receive({19});
-    EXPECT_RESPONSE({19, 0xAA, 0xBB, 0xCC, 0xDD}, response);
+    EXPECT_RESPONSE({0, 19, 0xAA, 0xBB, 0xCC, 0xDD}, response);
 }
 
 // Decode function f20 which returns nested custom types
@@ -283,7 +283,7 @@ TEST_F(TestServer1, decodeF20)
 {
     EXPECT_CALL(s0Service, f20()).WillOnce(Return(ts1::CompositeData3{{0xAA, 0xBB}, ts1::MyEnum::V2}));
     auto response = receive({20});
-    EXPECT_RESPONSE({20, 0xAA, 0xBB, 0x02}, response);
+    EXPECT_RESPONSE({0, 20, 0xAA, 0xBB, 0x02}, response);
 }
 
 // Decode function f21 which return two uint8_t args
@@ -291,7 +291,7 @@ TEST_F(TestServer1, decodef21)
 {
     EXPECT_CALL(s0Service, f21()).WillOnce(Return(std::tuple<uint8_t, uint8_t>{123, 111}));
     auto response = receive({21});
-    EXPECT_RESPONSE({21, 123, 111}, response);
+    EXPECT_RESPONSE({0, 21, 123, 111}, response);
 }
 
 // Decode function f22 that takes two string arguments and returns two strings
@@ -305,6 +305,7 @@ TEST_F(TestServer1, decodef22)
     EXPECT_CALL(s0Service, f22(arg1, arg2)).WillOnce(Return(std::tuple<etl::string<4>, etl::string<4>>{ret1, ret2}));
     auto response = receive({22, 'a', 'r', 'g', '1', '\0', 'a', 'r', 'g', '2', '\0'});
     EXPECT_RESPONSE({
+                        0,
                         22,
                         'r',
                         'e',
@@ -325,7 +326,7 @@ TEST_F(TestServer1, decodef23)
 {
     EXPECT_CALL(s0Service, f23()).WillOnce(Return(etl::string_view("Test")));
     auto response = receive({23});
-    EXPECT_RESPONSE({23, 'T', 'e', 's', 't', '\0'}, response);
+    EXPECT_RESPONSE({0, 23, 'T', 'e', 's', 't', '\0'}, response);
 }
 
 // Decode function that returns two auto strings
@@ -333,7 +334,7 @@ TEST_F(TestServer1, decodef24)
 {
     EXPECT_CALL(s0Service, f24()).WillOnce(Return(std::tuple<etl::string_view, etl::string_view>{"T1", "T2"}));
     auto response = receive({24});
-    EXPECT_RESPONSE({24, 'T', '1', '\0', 'T', '2', '\0'}, response);
+    EXPECT_RESPONSE({0, 24, 'T', '1', '\0', 'T', '2', '\0'}, response);
 }
 
 // Decode function that returns optional auto string
@@ -341,11 +342,11 @@ TEST_F(TestServer1, decodef25)
 {
     EXPECT_CALL(s0Service, f25()).WillOnce(Return(etl::optional<etl::string_view>{"T1"}));
     auto response = receive({25});
-    EXPECT_RESPONSE({25, 0x01, 'T', '1', '\0'}, response);
+    EXPECT_RESPONSE({0, 25, 0x01, 'T', '1', '\0'}, response);
 
     EXPECT_CALL(s0Service, f25()).WillOnce(Return(etl::optional<etl::string_view>{}));
     response = receive({25});
-    EXPECT_RESPONSE({25, 0x00}, response);
+    EXPECT_RESPONSE({0, 25, 0x00}, response);
 }
 
 // Decode function that returns array of auto string
@@ -353,5 +354,5 @@ TEST_F(TestServer1, decodef26)
 {
     EXPECT_CALL(s0Service, f26()).WillOnce(Return(etl::array<etl::string_view, 3>{"Test1", "T2", "T3"}));
     auto response = receive({26});
-    EXPECT_RESPONSE({26, 'T', 'e', 's', 't', '1', '\0', 'T', '2', '\0', 'T', '3', '\0'}, response);
+    EXPECT_RESPONSE({0, 26, 'T', 'e', 's', 't', '1', '\0', 'T', '2', '\0', 'T', '3', '\0'}, response);
 }

--- a/tests/cpp/TestServer1.cpp
+++ b/tests/cpp/TestServer1.cpp
@@ -1,5 +1,5 @@
 #include "generated/Server1/Server1.hpp"
-#include "TestServerBase.hpp"
+#include "TestUtils.hpp"
 
 using ::testing::Return;
 namespace
@@ -37,7 +37,7 @@ public:
 };
 }
 
-using TestServer1 = TestServerBase<Mockservice>;
+using TestServer1 = testutils::TestServerBase<Mockservice>;
 
 static_assert(std::is_same<ts1::Server1, lrpc::Server<0, 100, 200>>::value, "RX and/or TX buffer size are unequal to the definition file");
 
@@ -89,7 +89,7 @@ TEST_F(TestServer1, decodeF4)
 TEST_F(TestServer1, decodeF5)
 {
     std::vector<uint16_t> expected{0xBBAA, 0xDDCC};
-    EXPECT_CALL(service, f5(SPAN_EQ(expected)));
+    EXPECT_CALL(service, f5(testutils::SPAN_EQ(expected)));
     auto response = receive("05AABBCCDD");
     EXPECT_RESPONSE("0005", response);
 }
@@ -133,7 +133,7 @@ TEST_F(TestServer1, decodeF9)
     std::vector<ts1::CompositeData2> expected{
         ts1::CompositeData2{0xAA, 0xBB},
         ts1::CompositeData2{0xCC, 0xDD}};
-    EXPECT_CALL(service, f9(SPAN_EQ(expected)));
+    EXPECT_CALL(service, f9(testutils::SPAN_EQ(expected)));
     auto response = receive("09AABBCCDD");
     EXPECT_RESPONSE("0009", response);
 }

--- a/tests/cpp/TestServer1.cpp
+++ b/tests/cpp/TestServer1.cpp
@@ -1,5 +1,4 @@
 #include "generated/Server1/Server1.hpp"
-#include "generated/Server1/s0_ServiceShim.hpp"
 #include "TestServerBase.hpp"
 
 using ::testing::Return;

--- a/tests/cpp/TestServer2_s0.cpp
+++ b/tests/cpp/TestServer2_s0.cpp
@@ -51,7 +51,7 @@ TEST_F(TestServer2, decodeF0)
 {
     EXPECT_CALL(service, f0(true, etl::string_view("Test")));
     auto response = receive({0, 0x01, 'T', 'e', 's', 't', '\0'});
-    EXPECT_RESPONSE({0}, response);
+    EXPECT_RESPONSE({0, 0}, response);
 }
 
 // Decode void function with auto string as first param
@@ -59,7 +59,7 @@ TEST_F(TestServer2, decodeF1)
 {
     EXPECT_CALL(service, f1(etl::string_view("Test"), true));
     auto response = receive({1, 'T', 'e', 's', 't', '\0', 0x01});
-    EXPECT_RESPONSE({1}, response);
+    EXPECT_RESPONSE({0, 1}, response);
 }
 
 // Decode void function with two auto string first params
@@ -68,5 +68,5 @@ TEST_F(TestServer2, decodeF2)
     using sv = etl::string_view;
     EXPECT_CALL(service, f2(sv("T1"), sv("T2")));
     auto response = receive({2, 'T', '1', '\0', 'T', '2', '\0'});
-    EXPECT_RESPONSE({2}, response);
+    EXPECT_RESPONSE({0, 2}, response);
 }

--- a/tests/cpp/TestServer2_s0.cpp
+++ b/tests/cpp/TestServer2_s0.cpp
@@ -1,7 +1,4 @@
-#include "generated/Server2/s00_ServiceShim.hpp"
 #include "generated/Server2/Server2.hpp"
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "TestServerBase.hpp"
 
 using ::testing::Return;

--- a/tests/cpp/TestServer2_s0.cpp
+++ b/tests/cpp/TestServer2_s0.cpp
@@ -2,6 +2,7 @@
 #include "generated/Server2/Server2.hpp"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <etl/to_arithmetic.h>
 
 using ::testing::Return;
 
@@ -18,9 +19,33 @@ class TestServer2 : public ::testing::Test
 public:
     MockS00Service service;
 
+    std::vector<uint8_t> hexToBytes(etl::string_view hex)
+    {
+        if (hex.size() % 2 != 0)
+        {
+            return {};
+        }
+
+        const auto numberBytes = hex.size() / 2;
+
+        std::vector<uint8_t> bytes;
+
+        for (auto i = 0U; i < numberBytes; i += 1)
+        {
+            bytes.emplace_back(etl::to_arithmetic<uint8_t>(hex.substr(i * 2, 2), etl::hex));
+        }
+
+        return bytes;
+    }
+
     void SetUp() override
     {
         responseBuffer.fill(0xAA);
+    }
+
+    etl::span<uint8_t> receive(const etl::string_view hex)
+    {
+        return receive(hexToBytes(hex));
     }
 
     etl::span<uint8_t> receive(const std::vector<uint8_t> &bytes)
@@ -34,10 +59,10 @@ public:
         return {responseBuffer.begin(), writer.size_bytes()};
     }
 
-    void EXPECT_RESPONSE(const std::vector<uint8_t> &expected, const etl::span<uint8_t> actual)
+    void EXPECT_RESPONSE(const etl::string_view expected, const etl::span<uint8_t> actual)
     {
         std::vector<uint8_t> actualVec{actual.begin(), actual.end()};
-        EXPECT_EQ(expected, actualVec);
+        EXPECT_EQ(hexToBytes(expected), actualVec);
     }
 
 private:
@@ -50,23 +75,23 @@ static_assert(std::is_same<Server2, lrpc::Server<1, 100, 256>>::value, "RX and/o
 TEST_F(TestServer2, decodeF0)
 {
     EXPECT_CALL(service, f0(true, etl::string_view("Test")));
-    auto response = receive({0, 0x01, 'T', 'e', 's', 't', '\0'});
-    EXPECT_RESPONSE({0, 0}, response);
+    auto response = receive("00015465737400");
+    EXPECT_RESPONSE("0000", response);
 }
 
 // Decode void function with auto string as first param
 TEST_F(TestServer2, decodeF1)
 {
     EXPECT_CALL(service, f1(etl::string_view("Test"), true));
-    auto response = receive({1, 'T', 'e', 's', 't', '\0', 0x01});
-    EXPECT_RESPONSE({0, 1}, response);
+    auto response = receive("01546573740001");
+    EXPECT_RESPONSE("0001", response);
 }
 
-// Decode void function with two auto string first params
+// Decode void function with two auto string params
 TEST_F(TestServer2, decodeF2)
 {
     using sv = etl::string_view;
     EXPECT_CALL(service, f2(sv("T1"), sv("T2")));
-    auto response = receive({2, 'T', '1', '\0', 'T', '2', '\0'});
-    EXPECT_RESPONSE({0, 2}, response);
+    auto response = receive("02543100543200");
+    EXPECT_RESPONSE("0002", response);
 }

--- a/tests/cpp/TestServer2_s0.cpp
+++ b/tests/cpp/TestServer2_s0.cpp
@@ -1,5 +1,5 @@
 #include "generated/Server2/Server2.hpp"
-#include "TestServerBase.hpp"
+#include "TestUtils.hpp"
 
 using ::testing::Return;
 
@@ -11,7 +11,7 @@ public:
     MOCK_METHOD(void, f2, (const etl::string_view &p0, const etl::string_view &p1), (override));
 };
 
-using TestServer2 = TestServerBase<MockS00Service>;
+using TestServer2 = testutils::TestServerBase<MockS00Service>;
 
 static_assert(std::is_same<Server2, lrpc::Server<1, 100, 256>>::value, "RX and/or TX buffer size are unequal to the definition file");
 

--- a/tests/cpp/TestServer2_s1.cpp
+++ b/tests/cpp/TestServer2_s1.cpp
@@ -1,33 +1,7 @@
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include "TestServerBase.hpp"
 #include "generated/Server2/s01_ServiceShim.hpp"
 
 using ::testing::Return;
-
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable:4100)
-#endif
-
-MATCHER_P(SPAN_EQ, e, "Equality matcher for etl::span")
-{
-    if (e.size() != arg.size())
-    {
-        return false;
-    }
-    for (size_t i = 0; i < e.size(); ++i)
-    {
-        if (e[i] != arg[i])
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
 
 class MockS01Service : public s01ServiceShim
 {
@@ -45,36 +19,7 @@ public:
     MOCK_METHOD(StringStruct2, f10, (), (override));
 };
 
-class TestServer2_s1 : public ::testing::Test
-{
-public:
-    MockS01Service service;
-
-    void SetUp() override
-    {
-        responseBuffer.fill(0xAA);
-    }
-
-    etl::span<uint8_t> receive(const std::vector<uint8_t> &bytes)
-    {
-        const etl::span<const uint8_t> s(bytes.begin(), bytes.end());
-
-        lrpc::Service::Reader reader(s.begin(), s.end(), etl::endian::little);
-        lrpc::Service::Writer writer(responseBuffer.begin(), responseBuffer.end(), etl::endian::little);
-        service.invoke(reader, writer);
-
-        return {responseBuffer.begin(), writer.size_bytes()};
-    }
-
-    void EXPECT_RESPONSE(const std::vector<uint8_t> &expected, const etl::span<uint8_t> actual)
-    {
-        std::vector<uint8_t> actualVec{actual.begin(), actual.end()};
-        EXPECT_EQ(expected, actualVec);
-    }
-
-private:
-    etl::array<uint8_t, 256> responseBuffer;
-};
+using TestServer2_s1 = TestServerBase<MockS01Service>;
 
 // Decode void function with array of strings param
 TEST_F(TestServer2_s1, decodeF0)
@@ -82,8 +27,8 @@ TEST_F(TestServer2_s1, decodeF0)
     using sv = etl::string_view;
     std::vector<sv> expected{sv("T1"), sv("T2")};
     EXPECT_CALL(service, f0(SPAN_EQ(expected)));
-    auto response = receive({0, 'T', '1', '\0', 'T', '2', '\0'});
-    EXPECT_RESPONSE({1, 0}, response);
+    auto response = receive("00543100543200");
+    EXPECT_RESPONSE("0100", response);
 }
 
 TEST_F(TestServer2_s1, decodeF0WithStringShorterThanMax)
@@ -91,8 +36,8 @@ TEST_F(TestServer2_s1, decodeF0WithStringShorterThanMax)
     using sv = etl::string_view;
     std::vector<sv> expected{sv("1"), sv("2")};
     EXPECT_CALL(service, f0(SPAN_EQ(expected)));
-    auto response = receive({0, '1', '\0', '2', '\0'});
-    EXPECT_RESPONSE({1, 0}, response);
+    auto response = receive("0031003200");
+    EXPECT_RESPONSE("0100", response);
 }
 
 // Decode function that returns array of strings
@@ -100,8 +45,8 @@ TEST_F(TestServer2_s1, decodeF1)
 {
     etl::array<etl::string<2>, 2> retVal{"T1", "T2"};
     EXPECT_CALL(service, f1()).WillOnce(Return(retVal));
-    auto response = receive({1});
-    EXPECT_RESPONSE({1, 1, 'T', '1', '\0', 'T', '2', '\0'}, response);
+    auto response = receive("01");
+    EXPECT_RESPONSE("0101543100543200", response);
 }
 
 // Decode void function with optional fixed size string param
@@ -110,8 +55,8 @@ TEST_F(TestServer2_s1, decodeF2)
     using sv = etl::string_view;
     etl::optional<sv> expected{"T1"};
     EXPECT_CALL(service, f2(expected));
-    auto response = receive({2, 0x01, 'T', '1', '\0'});
-    EXPECT_RESPONSE({1, 2}, response);
+    auto response = receive("0201543100");
+    EXPECT_RESPONSE("0102", response);
 }
 
 // Decode void function with optional auto string param
@@ -120,8 +65,8 @@ TEST_F(TestServer2_s1, decodeF3)
     using sv = etl::string_view;
     etl::optional<sv> expected{"T1"};
     EXPECT_CALL(service, f3(expected));
-    auto response = receive({3, 0x01, 'T', '1', '\0'});
-    EXPECT_RESPONSE({1, 3}, response);
+    auto response = receive("0301543100");
+    EXPECT_RESPONSE("0103", response);
 }
 
 // Decode function that returns optional string
@@ -129,8 +74,8 @@ TEST_F(TestServer2_s1, decodeF4)
 {
     etl::optional<etl::string<2>> expected{"T1"};
     EXPECT_CALL(service, f4()).WillOnce(Return(expected));
-    auto response = receive({4});
-    EXPECT_RESPONSE({1, 4, 0x01, 'T', '1', '\0'}, response);
+    auto response = receive("04");
+    EXPECT_RESPONSE("010401543100", response);
 }
 
 // Decode function that takes custom struct argument
@@ -142,8 +87,8 @@ TEST_F(TestServer2_s1, decodeF5)
     expected.c = "T4";
 
     EXPECT_CALL(service, f5(expected));
-    auto response = receive({5, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'});
-    EXPECT_RESPONSE({1, 5}, response);
+    auto response = receive("0554310054320054330001543400");
+    EXPECT_RESPONSE("0105", response);
 }
 
 // Decode function that returns custom struct
@@ -155,8 +100,8 @@ TEST_F(TestServer2_s1, decodeF6)
     retVal.c = "T4";
 
     EXPECT_CALL(service, f6()).WillOnce(Return(retVal));
-    auto response = receive({6});
-    EXPECT_RESPONSE({1, 6, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'}, response);
+    auto response = receive("06");
+    EXPECT_RESPONSE("010654310054320054330001543400", response);
 }
 
 // Decode function that takes auto string argument and returns fixed size string
@@ -165,8 +110,8 @@ TEST_F(TestServer2_s1, decodeF7)
     etl::string<5> retVal{"T1234"};
     etl::string_view expected{"T0"};
     EXPECT_CALL(service, f7(expected)).WillOnce(Return(retVal));
-    auto response = receive({7, 'T', '0', '\0'});
-    EXPECT_RESPONSE({1, 7, 'T', '1', '2', '3', '4', '\0'}, response);
+    auto response = receive("07543000");
+    EXPECT_RESPONSE("0107543132333400", response);
 }
 
 // Decode void function with array of auto strings param
@@ -175,8 +120,8 @@ TEST_F(TestServer2_s1, decodeF8)
     using sv = etl::string_view;
     std::vector<sv> expected{sv("T1"), sv("T2")};
     EXPECT_CALL(service, f8(SPAN_EQ(expected)));
-    auto response = receive({8, 'T', '1', '\0', 'T', '2', '\0'});
-    EXPECT_RESPONSE({1, 8}, response);
+    auto response = receive("08543100543200");
+    EXPECT_RESPONSE("0108", response);
 }
 
 // Decode function that takes custom struct argument
@@ -188,8 +133,8 @@ TEST_F(TestServer2_s1, decodeF9)
     expected.c = "T4";
 
     EXPECT_CALL(service, f9(expected));
-    auto response = receive({9, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'});
-    EXPECT_RESPONSE({1, 9}, response);
+    auto response = receive("0954310054320054330001543400");
+    EXPECT_RESPONSE("0109", response);
 }
 
 // Decode function that returns custom struct
@@ -201,6 +146,6 @@ TEST_F(TestServer2_s1, decodeF10)
     retVal.c = "T4";
 
     EXPECT_CALL(service, f10()).WillOnce(Return(retVal));
-    auto response = receive({10});
-    EXPECT_RESPONSE({1, 10, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'}, response);
+    auto response = receive("0A");
+    EXPECT_RESPONSE("010A54310054320054330001543400", response);
 }

--- a/tests/cpp/TestServer2_s1.cpp
+++ b/tests/cpp/TestServer2_s1.cpp
@@ -83,7 +83,7 @@ TEST_F(TestServer2_s1, decodeF0)
     std::vector<sv> expected{sv("T1"), sv("T2")};
     EXPECT_CALL(service, f0(SPAN_EQ(expected)));
     auto response = receive({0, 'T', '1', '\0', 'T', '2', '\0'});
-    EXPECT_RESPONSE({0}, response);
+    EXPECT_RESPONSE({1, 0}, response);
 }
 
 TEST_F(TestServer2_s1, decodeF0WithStringShorterThanMax)
@@ -92,7 +92,7 @@ TEST_F(TestServer2_s1, decodeF0WithStringShorterThanMax)
     std::vector<sv> expected{sv("1"), sv("2")};
     EXPECT_CALL(service, f0(SPAN_EQ(expected)));
     auto response = receive({0, '1', '\0', '2', '\0'});
-    EXPECT_RESPONSE({0}, response);
+    EXPECT_RESPONSE({1, 0}, response);
 }
 
 // Decode function that returns array of strings
@@ -101,7 +101,7 @@ TEST_F(TestServer2_s1, decodeF1)
     etl::array<etl::string<2>, 2> retVal{"T1", "T2"};
     EXPECT_CALL(service, f1()).WillOnce(Return(retVal));
     auto response = receive({1});
-    EXPECT_RESPONSE({1, 'T', '1', '\0', 'T', '2', '\0'}, response);
+    EXPECT_RESPONSE({1, 1, 'T', '1', '\0', 'T', '2', '\0'}, response);
 }
 
 // Decode void function with optional fixed size string param
@@ -111,7 +111,7 @@ TEST_F(TestServer2_s1, decodeF2)
     etl::optional<sv> expected{"T1"};
     EXPECT_CALL(service, f2(expected));
     auto response = receive({2, 0x01, 'T', '1', '\0'});
-    EXPECT_RESPONSE({2}, response);
+    EXPECT_RESPONSE({1, 2}, response);
 }
 
 // Decode void function with optional auto string param
@@ -121,7 +121,7 @@ TEST_F(TestServer2_s1, decodeF3)
     etl::optional<sv> expected{"T1"};
     EXPECT_CALL(service, f3(expected));
     auto response = receive({3, 0x01, 'T', '1', '\0'});
-    EXPECT_RESPONSE({3}, response);
+    EXPECT_RESPONSE({1, 3}, response);
 }
 
 // Decode function that returns optional string
@@ -130,7 +130,7 @@ TEST_F(TestServer2_s1, decodeF4)
     etl::optional<etl::string<2>> expected{"T1"};
     EXPECT_CALL(service, f4()).WillOnce(Return(expected));
     auto response = receive({4});
-    EXPECT_RESPONSE({4, 0x01, 'T', '1', '\0'}, response);
+    EXPECT_RESPONSE({1, 4, 0x01, 'T', '1', '\0'}, response);
 }
 
 // Decode function that takes custom struct argument
@@ -143,7 +143,7 @@ TEST_F(TestServer2_s1, decodeF5)
 
     EXPECT_CALL(service, f5(expected));
     auto response = receive({5, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'});
-    EXPECT_RESPONSE({5}, response);
+    EXPECT_RESPONSE({1, 5}, response);
 }
 
 // Decode function that returns custom struct
@@ -156,7 +156,7 @@ TEST_F(TestServer2_s1, decodeF6)
 
     EXPECT_CALL(service, f6()).WillOnce(Return(retVal));
     auto response = receive({6});
-    EXPECT_RESPONSE({6, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'}, response);
+    EXPECT_RESPONSE({1, 6, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'}, response);
 }
 
 // Decode function that takes auto string argument and returns fixed size string
@@ -166,7 +166,7 @@ TEST_F(TestServer2_s1, decodeF7)
     etl::string_view expected{"T0"};
     EXPECT_CALL(service, f7(expected)).WillOnce(Return(retVal));
     auto response = receive({7, 'T', '0', '\0'});
-    EXPECT_RESPONSE({7, 'T', '1', '2', '3', '4', '\0'}, response);
+    EXPECT_RESPONSE({1, 7, 'T', '1', '2', '3', '4', '\0'}, response);
 }
 
 // Decode void function with array of auto strings param
@@ -176,7 +176,7 @@ TEST_F(TestServer2_s1, decodeF8)
     std::vector<sv> expected{sv("T1"), sv("T2")};
     EXPECT_CALL(service, f8(SPAN_EQ(expected)));
     auto response = receive({8, 'T', '1', '\0', 'T', '2', '\0'});
-    EXPECT_RESPONSE({8}, response);
+    EXPECT_RESPONSE({1, 8}, response);
 }
 
 // Decode function that takes custom struct argument
@@ -189,7 +189,7 @@ TEST_F(TestServer2_s1, decodeF9)
 
     EXPECT_CALL(service, f9(expected));
     auto response = receive({9, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'});
-    EXPECT_RESPONSE({9}, response);
+    EXPECT_RESPONSE({1, 9}, response);
 }
 
 // Decode function that returns custom struct
@@ -202,5 +202,5 @@ TEST_F(TestServer2_s1, decodeF10)
 
     EXPECT_CALL(service, f10()).WillOnce(Return(retVal));
     auto response = receive({10});
-    EXPECT_RESPONSE({10, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'}, response);
+    EXPECT_RESPONSE({1, 10, 'T', '1', '\0', 'T', '2', '\0', 'T', '3', '\0', 0x01, 'T', '4', '\0'}, response);
 }

--- a/tests/cpp/TestServer2_s1.cpp
+++ b/tests/cpp/TestServer2_s1.cpp
@@ -1,5 +1,5 @@
-#include "TestServerBase.hpp"
 #include "generated/Server2/Server2.hpp"
+#include "TestServerBase.hpp"
 
 using ::testing::Return;
 

--- a/tests/cpp/TestServer2_s1.cpp
+++ b/tests/cpp/TestServer2_s1.cpp
@@ -1,5 +1,5 @@
 #include "TestServerBase.hpp"
-#include "generated/Server2/s01_ServiceShim.hpp"
+#include "generated/Server2/Server2.hpp"
 
 using ::testing::Return;
 

--- a/tests/cpp/TestServer2_s1.cpp
+++ b/tests/cpp/TestServer2_s1.cpp
@@ -1,5 +1,5 @@
 #include "generated/Server2/Server2.hpp"
-#include "TestServerBase.hpp"
+#include "TestUtils.hpp"
 
 using ::testing::Return;
 
@@ -19,14 +19,14 @@ public:
     MOCK_METHOD(StringStruct2, f10, (), (override));
 };
 
-using TestServer2_s1 = TestServerBase<MockS01Service>;
+using TestServer2_s1 = testutils::TestServerBase<MockS01Service>;
 
 // Decode void function with array of strings param
 TEST_F(TestServer2_s1, decodeF0)
 {
     using sv = etl::string_view;
     std::vector<sv> expected{sv("T1"), sv("T2")};
-    EXPECT_CALL(service, f0(SPAN_EQ(expected)));
+    EXPECT_CALL(service, f0(testutils::SPAN_EQ(expected)));
     auto response = receive("00543100543200");
     EXPECT_RESPONSE("0100", response);
 }
@@ -35,7 +35,7 @@ TEST_F(TestServer2_s1, decodeF0WithStringShorterThanMax)
 {
     using sv = etl::string_view;
     std::vector<sv> expected{sv("1"), sv("2")};
-    EXPECT_CALL(service, f0(SPAN_EQ(expected)));
+    EXPECT_CALL(service, f0(testutils::SPAN_EQ(expected)));
     auto response = receive("0031003200");
     EXPECT_RESPONSE("0100", response);
 }
@@ -119,7 +119,7 @@ TEST_F(TestServer2_s1, decodeF8)
 {
     using sv = etl::string_view;
     std::vector<sv> expected{sv("T1"), sv("T2")};
-    EXPECT_CALL(service, f8(SPAN_EQ(expected)));
+    EXPECT_CALL(service, f8(testutils::SPAN_EQ(expected)));
     auto response = receive("08543100543200");
     EXPECT_RESPONSE("0108", response);
 }

--- a/tests/cpp/TestServer3.cpp
+++ b/tests/cpp/TestServer3.cpp
@@ -1,6 +1,6 @@
 #include "generated/Server3/Server3.hpp"
 #include <sstream>
-#include "TestServerBase.hpp"
+#include "TestUtils.hpp"
 
 namespace
 {
@@ -33,7 +33,7 @@ public:
 
     void receive(const etl::string_view hex)
     {
-        lrpcReceive(::hexToBytes(hex));
+        lrpcReceive(testutils::hexToBytes(hex));
     }
 
     void lrpcTransmit(const etl::span<const uint8_t> bytes) override

--- a/tests/cpp/TestServer3.cpp
+++ b/tests/cpp/TestServer3.cpp
@@ -2,7 +2,9 @@
 #include <sstream>
 #include "TestServerBase.hpp"
 
-class s00Service : public srv3::s00ServiceShim
+namespace
+{
+class S00Service : public srv3::s00ServiceShim
 {
 public:
     uint8_t f0(uint8_t p1) override
@@ -11,7 +13,7 @@ public:
     }
 };
 
-class s01Service : public srv3::s01ServiceShim
+class S01Service : public srv3::s01ServiceShim
 {
 public:
     uint16_t f0(uint16_t p1) override
@@ -31,40 +33,36 @@ public:
 
     void receive(const etl::string_view hex)
     {
-        lrpcReceive(hexToBytes(hex));
+        lrpcReceive(::hexToBytes(hex));
     }
 
-    void lrpcTransmit(etl::span<const uint8_t> bytes) override
+    void lrpcTransmit(const etl::span<const uint8_t> bytes) override
     {
         std::stringstream stream;
         for (const auto b : bytes)
         {
-            stream << std::hex << std::setw(2) << std::uppercase << std::setfill('0') << static_cast<int>(b);
+            stream << std::hex << std::setw(2) << std::uppercase << std::setfill('0') << static_cast<uint32_t>(b);
         }
         transmitted += stream.str();
     }
 
-    void EXPECT_VECTOR_EQ(const std::string &v1, const std::string &v2)
-    {
-        EXPECT_EQ(v1, v2);
-    }
-
     std::string transmitted;
 
-    s00Service service00;
-    s01Service service01;
+    S00Service service00;
+    S01Service service01;
 };
+}
 
 static_assert(std::is_same<srv3::Server3, lrpc::Server<6, 256, 256>>::value, "RX and/or TX buffer size are unequal to the definition file");
 
 TEST_F(TestServer3, decodeI0)
 {
     receive("040000AA");
-    EXPECT_VECTOR_EQ("040000AA", transmitted);
+    EXPECT_EQ("040000AA", transmitted);
 }
 
 TEST_F(TestServer3, decodeI0AndI5)
 {
     receive("040000BB050508CCDD");
-    EXPECT_VECTOR_EQ("040000BB050508CCDD", transmitted);
+    EXPECT_EQ("040000BB050508CCDD", transmitted);
 }

--- a/tests/cpp/TestServerBase.hpp
+++ b/tests/cpp/TestServerBase.hpp
@@ -17,7 +17,9 @@ MATCHER_P(SPAN_EQ, e, "Equality matcher for etl::span")
     {
         return false;
     }
-    for (size_t i = 0; i < e.size(); ++i)
+
+    const auto size = e.size();
+    for (size_t i = 0; i < size; ++i)
     {
         if (e[i] != arg[i])
         {
@@ -31,9 +33,9 @@ MATCHER_P(SPAN_EQ, e, "Equality matcher for etl::span")
 # pragma warning(pop)
 #endif
 
-inline std::vector<uint8_t> hexToBytes(etl::string_view hex)
+inline std::vector<uint8_t> hexToBytes(const etl::string_view hex)
 {
-    if (hex.size() % 2 != 0)
+    if ((hex.size() % 2) != 0)
     {
         return {};
     }
@@ -71,18 +73,20 @@ public:
 
         lrpc::Service::Reader reader(s.begin(), s.end(), etl::endian::little);
         lrpc::Service::Writer writer(responseBuffer.begin(), responseBuffer.end(), etl::endian::little);
-        service.invoke(reader, writer);
+        auto invokeOk = service.invoke(reader, writer);
+
+        EXPECT_TRUE(invokeOk);
 
         return {responseBuffer.begin(), writer.size_bytes()};
     }
 
-    void EXPECT_RESPONSE(const etl::string_view expected, const etl::span<uint8_t> actual)
+    void EXPECT_RESPONSE(const etl::string_view expected, const etl::span<uint8_t> actual) const
     {
-        std::vector<uint8_t> actualVec{actual.begin(), actual.end()};
-        EXPECT_EQ(hexToBytes(expected), actualVec);
+        const std::vector<uint8_t> actualVec{actual.begin(), actual.end()};
+        EXPECT_EQ(::hexToBytes(expected), actualVec);
     }
 
-    etl::array<uint8_t, 256> responseBuffer;
+    etl::array<uint8_t, 256> responseBuffer {};
 
     Service service;
 };

--- a/tests/cpp/TestServerBase.hpp
+++ b/tests/cpp/TestServerBase.hpp
@@ -52,6 +52,8 @@ inline std::vector<uint8_t> hexToBytes(const etl::string_view hex)
     return bytes;
 }
 
+namespace
+{
 template <typename Service>
 class TestServerBase : public ::testing::Test
 {
@@ -63,7 +65,7 @@ public:
 
     etl::span<uint8_t> receive(const etl::string_view hex)
     {
-        return receive(hexToBytes(hex));
+        return receive(::hexToBytes(hex));
     }
 
 
@@ -90,3 +92,4 @@ public:
 
     Service service;
 };
+}

--- a/tests/cpp/TestServerBase.hpp
+++ b/tests/cpp/TestServerBase.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <etl/to_arithmetic.h>
+#include <etl/array.h>
+#include <etl/span.h>
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable:4100)
+#endif
+
+MATCHER_P(SPAN_EQ, e, "Equality matcher for etl::span")
+{
+    if (e.size() != arg.size())
+    {
+        return false;
+    }
+    for (size_t i = 0; i < e.size(); ++i)
+    {
+        if (e[i] != arg[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+
+inline std::vector<uint8_t> hexToBytes(etl::string_view hex)
+{
+    if (hex.size() % 2 != 0)
+    {
+        return {};
+    }
+
+    const auto numberBytes = hex.size() / 2;
+
+    std::vector<uint8_t> bytes;
+
+    for (auto i = 0U; i < numberBytes; i += 1)
+    {
+        bytes.emplace_back(etl::to_arithmetic<uint8_t>(hex.substr(i * 2, 2), etl::hex));
+    }
+
+    return bytes;
+}
+
+template <typename Service>
+class TestServerBase : public ::testing::Test
+{
+public:
+    void SetUp() final
+    {
+        responseBuffer.fill(0xAA);
+    }
+
+    etl::span<uint8_t> receive(const etl::string_view hex)
+    {
+        return receive(hexToBytes(hex));
+    }
+
+
+    etl::span<uint8_t> receive(const std::vector<uint8_t> &bytes)
+    {
+        const etl::span<const uint8_t> s(bytes.begin(), bytes.end());
+
+        lrpc::Service::Reader reader(s.begin(), s.end(), etl::endian::little);
+        lrpc::Service::Writer writer(responseBuffer.begin(), responseBuffer.end(), etl::endian::little);
+        service.invoke(reader, writer);
+
+        return {responseBuffer.begin(), writer.size_bytes()};
+    }
+
+    void EXPECT_RESPONSE(const etl::string_view expected, const etl::span<uint8_t> actual)
+    {
+        std::vector<uint8_t> actualVec{actual.begin(), actual.end()};
+        EXPECT_EQ(hexToBytes(expected), actualVec);
+    }
+
+    etl::array<uint8_t, 256> responseBuffer;
+
+    Service service;
+};

--- a/tests/cpp/TestServerErrors.cpp
+++ b/tests/cpp/TestServerErrors.cpp
@@ -4,19 +4,21 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-class s00Service : public srv3::s00ServiceShim
+namespace
+{
+class S00Service : public srv3::s00ServiceShim
 {
 public:
-    uint8_t f0(uint8_t p1) override
+    uint8_t f0(const uint8_t p1) override
     {
         return p1;
     }
 };
 
-class s01Service : public srv3::s01ServiceShim
+class S01Service : public srv3::s01ServiceShim
 {
 public:
-    uint16_t f0(uint16_t p1) override
+    uint16_t f0(const uint16_t p1) override
     {
         return p1;
     }
@@ -36,7 +38,7 @@ public:
         lrpcReceive(bytes);
     }
 
-    void lrpcTransmit(etl::span<const uint8_t> bytes) override
+    void lrpcTransmit(const etl::span<const uint8_t> bytes) override
     {
         transmitted.insert(transmitted.end(), bytes.begin(), bytes.end());
     }
@@ -47,10 +49,10 @@ public:
     }
 
     std::vector<uint8_t> transmitted;
-    s00Service service00;
-    s01Service service01;
+    S00Service service00;
+    S01Service service01;
 };
-
+}
 
 TEST_F(TestServerErrors, decodeUnknownServiceLessThanMaxServiceId)
 {
@@ -79,4 +81,3 @@ TEST_F(TestServerErrors, decodeUnknownFunction)
     receive({0x05, 0x05, 0xAB, 0xCC, 0xDD});
     EXPECT_VECTOR_EQ({0x14, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, transmitted);
 }
-

--- a/tests/cpp/TestServerErrors.cpp
+++ b/tests/cpp/TestServerErrors.cpp
@@ -1,0 +1,82 @@
+#include "generated/Server3/Server3.hpp"
+#include "generated/Server3/s00_ServiceShim.hpp"
+#include "generated/Server3/s01_ServiceShim.hpp"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+class s00Service : public srv3::s00ServiceShim
+{
+public:
+    uint8_t f0(uint8_t p1) override
+    {
+        return p1;
+    }
+};
+
+class s01Service : public srv3::s01ServiceShim
+{
+public:
+    uint16_t f0(uint16_t p1) override
+    {
+        return p1;
+    }
+};
+
+class TestServerErrors : public ::testing::Test, public srv3::Server3
+{
+public:
+    TestServerErrors()
+    {
+        registerService(service00);
+        // service 5 is intentionally not registered
+    }
+
+    void receive(const std::vector<uint8_t> &bytes)
+    {
+        lrpcReceive(bytes);
+    }
+
+    void lrpcTransmit(etl::span<const uint8_t> bytes) override
+    {
+        transmitted.insert(transmitted.end(), bytes.begin(), bytes.end());
+    }
+
+    void EXPECT_VECTOR_EQ(const std::vector<uint8_t> &v1, const std::vector<uint8_t> &v2)
+    {
+        EXPECT_EQ(v1, v2);
+    }
+
+    std::vector<uint8_t> transmitted;
+    s00Service service00;
+    s01Service service01;
+};
+
+
+TEST_F(TestServerErrors, decodeUnknownServiceLessThanMaxServiceId)
+{
+    // Non-existing service 0x02 (smaller than MAX_SERVICE_ID), function ID 0xAB and no additional bytes
+    receive({0x03, 0x02, 0xAB});
+    EXPECT_VECTOR_EQ({0x14, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, transmitted);
+}
+
+TEST_F(TestServerErrors, decodeUnknownServiceGreaterThanMaxServiceId)
+{
+    // Non-existing service 0x77 (greater than MAX_SERVICE_ID), function ID 0 and two additional bytes
+    receive({0x05, 0x77, 0x00, 0x00, 0x00});
+    EXPECT_VECTOR_EQ({0x14, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, transmitted);
+}
+
+TEST_F(TestServerErrors, decodeUnregistereredService)
+{
+    receive({0x05, 0x05, 0x08, 0xCC, 0xDD});
+    EXPECT_VECTOR_EQ({0x14, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, transmitted);
+}
+
+TEST_F(TestServerErrors, decodeUnknownFunction)
+{
+    // register service s01 (ID 5) and call non-existing function with ID 0xAB and two additional bytes
+    registerService(service01);
+    receive({0x05, 0x05, 0xAB, 0xCC, 0xDD});
+    EXPECT_VECTOR_EQ({0x14, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, transmitted);
+}
+

--- a/tests/cpp/TestServerErrors.cpp
+++ b/tests/cpp/TestServerErrors.cpp
@@ -1,5 +1,5 @@
 #include "generated/Server3/Server3.hpp"
-#include "TestServerBase.hpp"
+#include "TestUtils.hpp"
 #include <sstream>
 
 namespace
@@ -33,7 +33,7 @@ public:
 
     void receive(const etl::string_view hex)
     {
-        lrpcReceive(::hexToBytes(hex));
+        lrpcReceive(testutils::hexToBytes(hex));
     }
 
     void lrpcTransmit(const etl::span<const uint8_t> bytes) override

--- a/tests/cpp/TestUtils.hpp
+++ b/tests/cpp/TestUtils.hpp
@@ -9,10 +9,11 @@
 namespace testutils
 {
 
-    #ifdef _MSC_VER
-    # pragma warning(push)
-    # pragma warning(disable:4100)
-    #endif
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable:4100)
+#endif
+
 MATCHER_P(SPAN_EQ, e, "Equality matcher for etl::span")
 {
     if (e.size() != arg.size())

--- a/tests/cpp/TestUtils.hpp
+++ b/tests/cpp/TestUtils.hpp
@@ -6,11 +6,13 @@
 #include <etl/array.h>
 #include <etl/span.h>
 
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable:4100)
-#endif
+namespace testutils
+{
 
+    #ifdef _MSC_VER
+    # pragma warning(push)
+    # pragma warning(disable:4100)
+    #endif
 MATCHER_P(SPAN_EQ, e, "Equality matcher for etl::span")
 {
     if (e.size() != arg.size())
@@ -52,8 +54,6 @@ inline std::vector<uint8_t> hexToBytes(const etl::string_view hex)
     return bytes;
 }
 
-namespace
-{
 template <typename Service>
 class TestServerBase : public ::testing::Test
 {
@@ -65,7 +65,7 @@ public:
 
     etl::span<uint8_t> receive(const etl::string_view hex)
     {
-        return receive(::hexToBytes(hex));
+        return receive(testutils::hexToBytes(hex));
     }
 
 
@@ -85,7 +85,7 @@ public:
     void EXPECT_RESPONSE(const etl::string_view expected, const etl::span<uint8_t> actual) const
     {
         const std::vector<uint8_t> actualVec{actual.begin(), actual.end()};
-        EXPECT_EQ(::hexToBytes(expected), actualVec);
+        EXPECT_EQ(testutils::hexToBytes(expected), actualVec);
     }
 
     etl::array<uint8_t, 256> responseBuffer {};

--- a/tests/python/test_lrpc_client.py
+++ b/tests/python/test_lrpc_client.py
@@ -66,3 +66,19 @@ def test_decode_invalid_function_id() -> None:
     with pytest.raises(ValueError):
         encoded = b"\x04\x01\xAA\x02"
         client.decode(encoded)
+
+def test_decode_message_too_short() -> None:
+    with pytest.raises(ValueError):
+        client.decode(b"")
+
+    with pytest.raises(ValueError):
+        client.decode(b"\x04")
+
+    with pytest.raises(ValueError):
+        client.decode(b"\x04\x01")
+
+def test_decode_error_response() -> None:
+    with pytest.raises(ValueError) as e:
+        client.decode(b"\x13\xFF\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+
+    assert str(e.value) == "The LRPC server reported an error"


### PR DESCRIPTION
* Proper error message in lrpc_client.py when decoding a message smaller than 3 bytes. Previously this resulted in index out of range error
* Service::id method now returns uint8_t iso uint32_t
* Service::invoke now returns bool so that the service can fail to invoke and report this to the server
* Server::NullService now responds with an error message
* Service shim classes are now responsible for writing the service ID. The server used to do this
* Fixed generation of LRPC core file. It now depends on LRPC_IS_BUILT
* Basic error reporting in LrpcClient::decode