### PR TITLE
LRPC-94 LRPCC fails on enum parameter

### DIFF
--- a/src/lrpc/client/client_cli_visitor.py
+++ b/src/lrpc/client/client_cli_visitor.py
@@ -148,9 +148,6 @@ class ClientCliVisitor(LrpcVisitor):
         if param.base_type_is_string():
             t = click.STRING
 
-        if param.base_type_is_enum():
-            t = click.Choice(self.enum_values[param.base_type()])
-
         if param.base_type_is_float():
             t = click.FLOAT
 
@@ -158,10 +155,14 @@ class ClientCliVisitor(LrpcVisitor):
             t = click.BOOL
 
         if param.base_type_is_custom():
-            t = YamlParamType()
+            if param.base_type_is_enum():
+                t = click.Choice(self.enum_values[param.base_type()])
+
+            if param.base_type_is_struct():
+                t = YamlParamType()
 
         if param.is_optional():
-            return OptionalParamType(t)
+            t = OptionalParamType(t)
 
         return t
 

--- a/tests/lrpcc/server.yaml
+++ b/tests/lrpcc/server.yaml
@@ -7,8 +7,7 @@
 # TODO: LRPC-91 LRPCC fails on array parameter
 # - {cli: "lrpcc s0 f5 43981 52671", write: "070005CDABBFCD", read: "030005", response: ""}
 - {cli: 'lrpcc s0 f6 "lorem ipsum"', write: "1800066C6F72656D20697073756D00000000000000000000", read: "030006", response: ""}
-# TODO: LRPC-94 LRPCC fails on enum parameter
-# - {cli: "lrpcc s0 f8 V2", write: "04000802", read: "030008", response: ""}
+- {cli: "lrpcc s0 f8 V2", write: "04000802", read: "030008", response: ""}
 - {cli: "lrpcc s0 f11 171 205", write: "05000BABCD", read: "03000B", response: ""}
 - {cli: "lrpcc s0 f12", write: "03000C", read: "04000CAB", response: "a: 171 (0xab)"}
 - {cli: "lrpcc s0 f13", write: "03000D", read: "05000DCDAB", response: "a: 43981 (0xabcd)"}

--- a/tests/lrpcc/test_lrpcc.py
+++ b/tests/lrpcc/test_lrpcc.py
@@ -22,4 +22,5 @@ def test_lrpcc(cli: str, response: str) -> None:
     result = subprocess.run(cli, shell=True, capture_output=True, check=False)
 
     assert result.returncode == 0
+    assert result.stderr.decode().strip() == ""
     assert result.stdout.decode().strip() == response.replace("\r\n", os.linesep)


### PR DESCRIPTION
* Fixed issue. Enabled test
* Improved LRPCC tests by making sure stderr is empty after call to LRPCC