### PR TITLE
LRPC-91 LRPCC fails on array parameter

### DIFF
--- a/src/lrpc/client/encoder.py
+++ b/src/lrpc/client/encoder.py
@@ -58,8 +58,8 @@ def __encode_struct(value: Any, var: LrpcVar, lrpc_def: LrpcDef) -> bytes:
 
 
 def __check_array(value: Any, var: LrpcVar) -> None:
-    if not isinstance(value, list):
-        raise TypeError(f"Type error for {var.name()}: expected array/list, but got {type(value)}")
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(f"Type error for {var.name()}: expected list or tuple, but got {type(value)}")
 
     if len(value) != var.array_size():
         raise ValueError(f"Length error for {var.name()}: expected {var.array_size()}, but gor {len(value)}")

--- a/tests/lrpcc/server.yaml
+++ b/tests/lrpcc/server.yaml
@@ -4,8 +4,7 @@
 - {cli: "lrpcc s0 f2 171", write: "040002AB", read: "030002", response: ""}
 - {cli: "lrpcc s0 f3 43981", write: "050003CDAB", read: "030003", response: ""}
 - {cli: "lrpcc s0 f4 123.456", write: "07000479E9F642", read: "030004", response: ""}
-# TODO: LRPC-91 LRPCC fails on array parameter
-# - {cli: "lrpcc s0 f5 43981 52671", write: "070005CDABBFCD", read: "030005", response: ""}
+- {cli: "lrpcc s0 f5 43981 52671", write: "070005CDABBFCD", read: "030005", response: ""}
 - {cli: 'lrpcc s0 f6 "lorem ipsum"', write: "1800066C6F72656D20697073756D00000000000000000000", read: "030006", response: ""}
 - {cli: "lrpcc s0 f8 V2", write: "04000802", read: "030008", response: ""}
 - {cli: "lrpcc s0 f11 171 205", write: "05000BABCD", read: "03000B", response: ""}


### PR DESCRIPTION
* LRPC encoder can encode array type from Python list or tuple (which is what Click produces)
* Enable test