### PR TITLE
#294 Rename communicate_single to communicate

### DIFF
--- a/changes/294.misc.md
+++ b/changes/294.misc.md
@@ -1,3 +1,3 @@
 Rename function `communicate` in `LrpcClient` to `communicate_all` and function `communicate_single` to `communicate`
 
-> ⚠ Breaking change: Function `LrpcClient.communicate` still exists but has different functionality. Migration guide: replace existing calls to `LrpcClient.communicate` with `LrpcClient.communicate_all` and existing calls to `LrpcClient.communicate_singe` with `LrpcClient.communicate`.
+> ⚠ Breaking change: Function `LrpcClient.communicate` still exists but has different functionality. Migration guide: replace existing calls to `LrpcClient.communicate` with `LrpcClient.communicate_all` and existing calls to `LrpcClient.communicate_single` with `LrpcClient.communicate`.

--- a/changes/294.misc.md
+++ b/changes/294.misc.md
@@ -1,0 +1,3 @@
+Rename function `communicate` in `LrpcClient` to `communicate_all` and function `communicate_single` to `communicate`
+
+> ⚠ Breaking change: Function `LrpcClient.communicate` still exists but has different functionality. Migration guide: replace existing calls to `LrpcClient.communicate` with `LrpcClient.communicate_all` and existing calls to `LrpcClient.communicate_singe` with `LrpcClient.communicate`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -131,10 +131,10 @@ port = serial.Serial(port="COM3", baudrate=115200, timeout=2)
 client = LrpcClient(lrpc_def, port)
 
 for resp in client.communicate_all("calc", "add", a=3, b=7):
-    print(resp["result"])   # 10
+    print(resp.payload["result"])   # 10
 
 for resp in client.communicate_all("calc", "multiply", a=6, b=7):
-    print(resp["result"])   # 42
+    print(resp.payload["result"])   # 42
 ```
 
 ---

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -130,10 +130,10 @@ lrpc_def = load_lrpc_def("math.lrpc.yaml")
 port = serial.Serial(port="COM3", baudrate=115200, timeout=2)
 client = LrpcClient(lrpc_def, port)
 
-for resp in client.communicate("calc", "add", a=3, b=7):
+for resp in client.communicate_all("calc", "add", a=3, b=7):
     print(resp["result"])   # 10
 
-for resp in client.communicate("calc", "multiply", a=6, b=7):
+for resp in client.communicate_all("calc", "multiply", a=6, b=7):
     print(resp["result"])   # 42
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -176,7 +176,7 @@ Run `lrpcc --help` for a full list of available services and functions.
 
 ### Custom Python client
 
-To communicate from your own Python code, create an `LrpcClient` and call `communicate_single`:
+To communicate from your own Python code, create an `LrpcClient` and call `communicate`:
 
 ``` python
 from lrpc.client import LrpcClient
@@ -188,11 +188,11 @@ transport = serial.Serial(port="COM3", baudrate=115200, timeout=2)
 
 client = LrpcClient(lrpc_def, transport)
 
-response = client.communicate_single("math", "add", a=3, b=7)
+response = client.communicate("math", "add", a=3, b=7)
 print(response.payload["result"])   # prints: 10
 ```
 
-`communicate_single` is a convenience wrapper around `communicate` that returns the first response directly. Use `communicate` when receiving stream response messages — it is a generator that yields one response per message received from the server.
+`communicate` returns the first response directly. Use `communicate_all` when receiving stream response messages — it is a generator that yields one response per message received from the server.
 
 For the full Python client API — streams, error responses, `encode`/`decode`, version checking — see the [Python client API reference](python-api/client.md).
 
@@ -259,11 +259,11 @@ services:
           - { name: value, type: int32_t }
 ```
 
-Receive all messages from the stream using `communicate`:
+Receive all messages from the stream using `communicate_all`:
 
 ``` python
 # print each value returned from the server
-for response in client.communicate("math", "results", start=True):
+for response in client.communicate_all("math", "results", start=True):
     print(response.payload["value"])
 ```
 

--- a/docs/python-api/client.md
+++ b/docs/python-api/client.md
@@ -67,10 +67,23 @@ If `save_to` is given, the retrieved definition is written to that path as a YAM
 ### communicate
 
 ``` python
-communicate(service_name: str, function_or_stream_name: str, **kwargs) -> Generator[LrpcResponse, ...]
+communicate(service_name: str, function_or_stream_name: str, **kwargs) -> LrpcResponse
 ```
 
-The primary communication method. Encodes the call, writes it to the transport, then reads and yields responses. Pass function arguments or stream parameters as keyword arguments.
+Convenience wrapper around `communicate_all` that returns the first response directly. Use for regular function calls where exactly one response is expected.
+
+``` python
+response = client.communicate("math", "add", a=3, b=7)
+print(response.payload["result"])   # 10
+```
+
+### communicate_all
+
+``` python
+communicate_all(service_name: str, function_or_stream_name: str, **kwargs) -> Generator[LrpcResponse, ...]
+```
+
+Encodes the call, writes it to the transport, then reads and yields all responses. Pass function arguments or stream parameters as keyword arguments.
 
 Response behavior depends on the call type:
 
@@ -84,38 +97,21 @@ Response behavior depends on the call type:
 For **finite streams**, the implicit `final` field is automatically removed from each response payload before yielding. Reading continues as long as `final` was `False` on the last message.
 
 ``` python
-# Function call — yields exactly once
-for response in client.communicate("math", "add", a=3, b=7):
-    print(response.payload["result"])   # 10
-
 # Server stream — start it and collect messages
-for response in client.communicate("sensor", "readings", start=True):
+for response in client.communicate_all("sensor", "readings", start=True):
     print(response.payload["value"])
 
 # Stop a server stream
-next(client.communicate("sensor", "readings", start=False), None)
+next(client.communicate_all("sensor", "readings", start=False), None)
 
 # Client stream — fire and forget
-next(client.communicate("logger", "write", message="hello"), None)
+next(client.communicate_all("logger", "write", message="hello"), None)
 
 # Finite client stream — mark the last message
-next(client.communicate("logger", "write", message="last", final=True), None)
+next(client.communicate_all("logger", "write", message="last", final=True), None)
 ```
 
 Raises `TimeoutError` if the transport times out while waiting for a response.
-
-### communicate_single
-
-``` python
-communicate_single(service_name: str, function_or_stream_name: str, **kwargs) -> LrpcResponse
-```
-
-Convenience wrapper that calls `communicate` and returns the first response. Use for regular function calls where exactly one response is expected.
-
-``` python
-response = client.communicate_single("math", "add", a=3, b=7)
-print(response.payload["result"])   # 10
-```
 
 ### encode
 
@@ -151,7 +147,7 @@ Returns `True` if all three match. Logs a warning for each mismatch and returns 
 
 ## LrpcResponse
 
-`LrpcResponse` is a dataclass returned by `communicate` and `communicate_single`:
+`LrpcResponse` is a dataclass returned by `communicate` and `communicate_all`:
 
 ``` python
 @dataclass

--- a/src/lrpc/client/lrpc_client.py
+++ b/src/lrpc/client/lrpc_client.py
@@ -71,7 +71,7 @@ class LrpcClient:
         client_side_def_version = self._lrpc_def.settings().version() or disabled
 
         def get_server_version() -> MetaVersionResponseDict:
-            version_response = self.communicate_single("LrpcMeta", "version").payload
+            version_response = self.communicate("LrpcMeta", "version").payload
             MetaVersionResponseValidator.validate_python(version_response, strict=True, extra="forbid")
             return cast(MetaVersionResponseDict, version_response)
 
@@ -184,7 +184,7 @@ class LrpcClient:
 
         raise ValueError(f"Function or stream {function_or_stream_name} not found in service {service_name}")
 
-    def communicate(
+    def communicate_all(
         self,
         service_name: str,
         function_or_stream_name: str,
@@ -216,13 +216,13 @@ class LrpcClient:
 
             yield response
 
-    def communicate_single(
+    def communicate(
         self,
         service_name: str,
         function_or_stream_name: str,
         **kwargs: LrpcType,
     ) -> LrpcResponse:
-        return next(self.communicate(service_name, function_or_stream_name, **kwargs))
+        return next(self.communicate_all(service_name, function_or_stream_name, **kwargs))
 
     def _has_response(self, service_name: str, function_or_stream_name: str, *, start_param: bool) -> bool:
         function = self._lrpc_def.function(service_name, function_or_stream_name)
@@ -316,7 +316,7 @@ class LrpcClient:
 
     def _retrieve_definition(self, save_to: Path | None = None) -> LrpcDef | None:
         compressed_definition = b""
-        for response in self.communicate("LrpcMeta", "definition", start=True):
+        for response in self.communicate_all("LrpcMeta", "definition", start=True):
             chunk = response.payload.get("chunk")
             if not isinstance(chunk, bytes):
                 raise TypeError("Invalid response while retrieving definition from server")

--- a/src/lrpc/tools/lrpcc/lrpcc.py
+++ b/src/lrpc/tools/lrpcc/lrpcc.py
@@ -177,7 +177,7 @@ class Lrpcc:
         return transport
 
     def _command_handler(self, service_name: str, function_or_stream_name: str, **kwargs: LrpcType) -> None:
-        for index, response in enumerate(self.client.communicate(service_name, function_or_stream_name, **kwargs)):
+        for index, response in enumerate(self.client.communicate_all(service_name, function_or_stream_name, **kwargs)):
             self._print_response(response, index)
 
     @staticmethod

--- a/tests/python/test_lrpc_client.py
+++ b/tests/python/test_lrpc_client.py
@@ -265,7 +265,7 @@ class TestLrpcClient:
 
     def test_communicate_function(self) -> None:
         response_bytes = b"\x03\x01\x00\xcd"
-        response = self.client(response_bytes).communicate_single("srv1", "add5", p0=0xAB)
+        response = self.client(response_bytes).communicate("srv1", "add5", p0=0xAB)
         payload = response.payload
 
         assert "r0" in payload
@@ -281,7 +281,7 @@ class TestLrpcClient:
 
     def test_communicate_function_bytearray(self) -> None:
         response_bytes = b"\x05\x01\x02\x02\x33\x44"
-        response = self.client(response_bytes).communicate_single("srv1", "bytearray", p0=b"\x11\x22")
+        response = self.client(response_bytes).communicate("srv1", "bytearray", p0=b"\x11\x22")
         payload = response.payload
 
         assert "r0" in payload
@@ -298,7 +298,7 @@ class TestLrpcClient:
     def test_communicate_function_wrong_response(self, caplog: pytest.LogCaptureFixture) -> None:
         # response belongs to srv0.f0
         response_bytes = b"\x02\x00\x00"
-        response = self.client(response_bytes).communicate_single("srv1", "add5", p0=0xAB)
+        response = self.client(response_bytes).communicate("srv1", "add5", p0=0xAB)
         payload = response.payload
 
         assert len(payload.items()) == 0
@@ -315,7 +315,7 @@ class TestLrpcClient:
 
     def test_communicate_function_error_response(self, caplog: pytest.LogCaptureFixture) -> None:
         response_bytes = b"\x0a\xff\x00\x00\x55\x66\x00\x00\x00\x77\x00"
-        response = self.client(response_bytes).communicate_single("srv1", "add5", p0=0xAB)
+        response = self.client(response_bytes).communicate("srv1", "add5", p0=0xAB)
 
         assert response.is_error_response
         assert response.is_expected_response is False
@@ -328,28 +328,28 @@ class TestLrpcClient:
         assert caplog.messages[0] == "Server reported error 'UnknownService' for call to srv1.add5"
 
     def test_communicate_stream_client_infinite(self) -> None:
-        communicator = self.client().communicate("srv2", "client_infinite", p0=0xAB, p1=0xCDEF)
+        communicator = self.client().communicate_all("srv2", "client_infinite", p0=0xAB, p1=0xCDEF)
         response = next(communicator, None)
         assert response is None
 
     def test_communicate_stream_client_finite(self) -> None:
-        communicator = self.client().communicate("srv2", "client_finite", p0=0xAB, p1=0xCDEF, final=True)
+        communicator = self.client().communicate_all("srv2", "client_finite", p0=0xAB, p1=0xCDEF, final=True)
         response = next(communicator, None)
         assert response is None
 
     def test_communicate_stream_server_infinite_stop(self) -> None:
-        communicator = self.client().communicate("srv2", "server_infinite", start=False)
+        communicator = self.client().communicate_all("srv2", "server_infinite", start=False)
         response = next(communicator, None)
         assert response is None
 
     def test_communicate_stream_server_finite_stop(self) -> None:
-        communicator = self.client().communicate("srv2", "server_finite", start=False)
+        communicator = self.client().communicate_all("srv2", "server_finite", start=False)
         response = next(communicator, None)
         assert response is None
 
     def test_communicate_stream_server_infinite_start(self) -> None:
         response_bytes = b"\x05\x02\x02\xcd\x01\x02"
-        response_generator = self.client(response_bytes).communicate("srv2", "server_infinite", start=True)
+        response_generator = self.client(response_bytes).communicate_all("srv2", "server_infinite", start=True)
         response = next(response_generator)
         payload = response.payload
 
@@ -373,7 +373,7 @@ class TestLrpcClient:
 
     def test_communicate_stream_server_finite_start(self) -> None:
         response_bytes = b"\x06\x02\x03\xcd\x01\x02\x01"
-        response = self.client(response_bytes).communicate_single("srv2", "server_finite", start=True)
+        response = self.client(response_bytes).communicate("srv2", "server_finite", start=True)
         payload = response.payload
 
         assert "p0" in payload


### PR DESCRIPTION
# :sparkle: @coderabbitai

## Description

Fixes issue #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Renamed `LrpcClient.communicate_single()` to `communicate()` for single-response calls.
  * Renamed `LrpcClient.communicate()` to `communicate_all()` for multi-response and streaming scenarios.
  * The new `communicate()` method now returns a single response directly.

* **Documentation**
  * Updated API documentation and usage examples to reflect the new method names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Type

- [ ] feature
- [ ] bugfix
- [ ] doc
- [ ] removal
- [x] misc
