### PR TITLE
#196 etlrwextensions cleanup

### DIFF
--- a/changes/196.misc.md
+++ b/changes/196.misc.md
@@ -1,0 +1,1 @@
+EtlRwExtensions cleanup

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -43,6 +43,7 @@ function(target_set_warnings target access)
     -Wimplicit-fallthrough
     -Wmisleading-indentation
     -Wundef
+    -Wextra-semi
     -fno-common
   )
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,8 @@ sonar.projectName=LotusRpc
 sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file
-sonar.sources=tests,src/lrpc
+sonar.sources=src/lrpc
+sonar.tests=tests
 
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.10, 3.11, 3.12, 3.13, 3.14

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,8 +6,7 @@ sonar.projectName=LotusRpc
 sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file
-sonar.sources=src/lrpc
-sonar.tests=tests
+sonar.sources=tests,src/lrpc
 
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.10, 3.11, 3.12, 3.13, 3.14

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -221,7 +221,7 @@ namespace lrpc
             skipSize = stringSize;
         }
 
-        const lrpc::string_view readValue{reader.end(), stringSize};
+        const lrpc::string_view readValue{reader.free_data().cbegin(), stringSize};
         (void)reader.read_unchecked<uint8_t>(skipSize);
         return readValue;
     };
@@ -247,7 +247,7 @@ namespace lrpc
 
         const auto fixedSlotSize = definitionStringSize + 1;
         const auto skipSize = std::min(reader.available_bytes(), fixedSlotSize);
-        const lrpc::string_view readValue{reader.end(), actualStringSize};
+        const lrpc::string_view readValue{reader.free_data().cbegin(), actualStringSize};
 
         (void)reader.skip<uint8_t>(skipSize);
 

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -112,7 +112,7 @@ namespace lrpc
     template <typename T>
     struct array_param_type<tags::array_n<T>>
     {
-        using type = lrpc::span<const T>;
+        using type = lrpc::span<const typename array_n_type<tags::array_n<T>>::type>;
     };
 
     template <>
@@ -141,7 +141,7 @@ namespace lrpc
     template <typename T>
     struct array_outparam_type<tags::array_n<T>>
     {
-        using type = lrpc::span<T>;
+        using type = lrpc::span<typename array_n_type<tags::array_n<T>>::type>;
     };
 
     template <>

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -112,7 +112,7 @@ namespace lrpc
     template <typename T>
     struct array_param_type<tags::array_n<T>>
     {
-        using type = lrpc::span<const typename array_n_type<typename tags::array_n<T>>::type>;
+        using type = lrpc::span<const T>;
     };
 
     template <>
@@ -141,7 +141,7 @@ namespace lrpc
     template <typename T>
     struct array_outparam_type<tags::array_n<T>>
     {
-        using type = lrpc::span<typename array_n_type<typename tags::array_n<T>>::type>;
+        using type = lrpc::span<T>;
     };
 
     template <>

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -305,6 +305,28 @@ namespace lrpc
         return {};
     }
 
+    template <typename T>
+    std::enable_if_t<std::is_arithmetic<T>::value> skip_n_unchecked(etl::byte_stream_reader& reader, size_t n)
+    {
+        (void)reader.skip<T>(n);
+    }
+
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value> skip_n_unchecked(etl::byte_stream_reader& reader, size_t n)
+    {
+        (void)reader.skip<uint8_t>(n);
+    }
+
+    template <typename T>
+    std::enable_if_t<!std::is_arithmetic<T>::value && !std::is_enum<T>::value>
+    skip_n_unchecked(etl::byte_stream_reader& reader, size_t n)
+    {
+        for (size_t i{0}; i < n; ++i)
+        {
+            (void)lrpc::read_unchecked<T>(reader);
+        }
+    }
+
     // Array, but not of fixed size string
     template <typename T>
     using enable_for_array = std::enable_if_t<is_array_n<T>::value && (!array_n_type_is_string_n<T>::value), void>;
@@ -319,16 +341,7 @@ namespace lrpc
             dest.at(i) = lrpc::read_unchecked<typename array_n_type<T>::type>(reader);
         }
 
-        if (size >= definitionArraySize)
-        {
-            return;
-        }
-
-        for (size_t i{0}; i < (definitionArraySize - size); ++i)
-        {
-            // discard elements that dont fit in the destination
-            (void)lrpc::read_unchecked<typename array_n_type<T>::type>(reader);
-        }
+        lrpc::skip_n_unchecked<typename array_n_type<T>::type>(reader, definitionArraySize - size);
     }
 
     // Array of fixed size string. Read as an array of lrpc::string_view

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -402,7 +402,7 @@ namespace lrpc
         }
 
         // fill remainder with null terminators
-        for (auto i = value.size(); i < definitionStringSize; ++i)
+        for (size_t i = writeSize; i < definitionStringSize; ++i)
         {
             writer.write_unchecked<char>('\0');
         }

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -20,7 +20,7 @@ namespace lrpc
 
         template <typename T>
         struct array_n;
-    };
+    }
 
     template <typename T>
     struct is_optional : public std::false_type
@@ -185,7 +185,7 @@ namespace lrpc
     enable_for_arithmetic<T> read_unchecked(etl::byte_stream_reader& reader)
     {
         return reader.read_unchecked<T>();
-    };
+    }
 
     // Enum
     template <typename T>
@@ -224,7 +224,7 @@ namespace lrpc
         const lrpc::string_view readValue{reader.free_data().cbegin(), stringSize};
         (void)reader.skip<uint8_t>(skipSize);
         return readValue;
-    };
+    }
 
     // Fixed size string
     template <typename T>
@@ -269,7 +269,7 @@ namespace lrpc
         const auto ba = reader.free_data().take<const lrpc::byte>(readSize);
         (void)reader.skip<lrpc::byte>(readSize);
         return ba;
-    };
+    }
 
     // Optional, but not of fixed size string
     template <typename T>
@@ -286,7 +286,7 @@ namespace lrpc
         }
 
         return {};
-    };
+    }
 
     // Optional of fixed size string. Read as an optional of lrpc::string_view
     template <typename T>
@@ -303,7 +303,7 @@ namespace lrpc
         }
 
         return {};
-    };
+    }
 
     // Array, but not of fixed size string
     template <typename T>
@@ -329,7 +329,7 @@ namespace lrpc
             // discard elements that dont fit in the destination
             (void)lrpc::read_unchecked<typename array_n_type<T>::type>(reader);
         }
-    };
+    }
 
     // Array of fixed size string. Read as an array of lrpc::string_view
     template <typename T>
@@ -351,7 +351,7 @@ namespace lrpc
         {
             reader.skip<uint8_t>((definitionArraySize - size) * (definitionStringSize + 1));
         }
-    };
+    }
 
     // deleted write function to allow specializations for custom structs
     template <typename T,
@@ -367,14 +367,14 @@ namespace lrpc
     void write_unchecked(etl::byte_stream_writer& writer, const ARI& value)
     {
         writer.write_unchecked<ARI>(value);
-    };
+    }
 
     // Enum
     template <typename ENUM, typename std::enable_if_t<std::is_enum<ENUM>::value, bool> = true>
     void write_unchecked(etl::byte_stream_writer& writer, const ENUM& value)
     {
         writer.write_unchecked<uint8_t>(static_cast<uint8_t>(value));
-    };
+    }
 
     // auto string
     template <typename T, typename std::enable_if_t<std::is_same<T, tags::string_auto>::value, bool> = true>
@@ -387,7 +387,7 @@ namespace lrpc
 
         // final null terminator
         writer.write_unchecked<char>('\0');
-    };
+    }
 
     // fixed size string
     template <typename T, typename std::enable_if_t<std::is_same<T, tags::string_n>::value, bool> = true>
@@ -409,7 +409,7 @@ namespace lrpc
 
         // final null terminator
         writer.write_unchecked<char>('\0');
-    };
+    }
 
     // auto bytearray
     template <typename T, typename std::enable_if_t<std::is_same<T, tags::bytearray_auto>::value, bool> = true>
@@ -425,7 +425,7 @@ namespace lrpc
         {
             lrpc::write_unchecked<lrpc::byte>(writer, value.at(i));
         }
-    };
+    }
 
     // optional, but not of fixed size string
     template <typename OPT,
@@ -437,7 +437,7 @@ namespace lrpc
         {
             lrpc::write_unchecked<typename optional_type<OPT>::type>(writer, value.value());
         }
-    };
+    }
 
     // optional fixed size string
     template <typename OPT, typename std::enable_if_t<is_optional_string_n<OPT>::value, bool> = true>
@@ -449,7 +449,7 @@ namespace lrpc
         {
             lrpc::write_unchecked<tags::string_n>(writer, value.value(), definitionStringSize);
         }
-    };
+    }
 
     // array but not of fixed size string
     template <typename ARR,
@@ -472,7 +472,7 @@ namespace lrpc
         {
             lrpc::write_unchecked<typename array_n_type<ARR>::type>(writer, {});
         }
-    };
+    }
 
     // array of fixed size string
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
@@ -497,5 +497,5 @@ namespace lrpc
         {
             lrpc::write_unchecked<tags::string_n>(writer, {}, definitionStringSize);
         }
-    };
+    }
 }

--- a/src/lrpc/resources/cpp/EtlRwExtensions.hpp
+++ b/src/lrpc/resources/cpp/EtlRwExtensions.hpp
@@ -222,7 +222,7 @@ namespace lrpc
         }
 
         const lrpc::string_view readValue{reader.free_data().cbegin(), stringSize};
-        (void)reader.read_unchecked<uint8_t>(skipSize);
+        (void)reader.skip<uint8_t>(skipSize);
         return readValue;
     };
 

--- a/src/lrpc/resources/cpp/Server.hpp
+++ b/src/lrpc/resources/cpp/Server.hpp
@@ -20,14 +20,14 @@ namespace lrpc
         class ServiceNotFoundService : public Service
         {
         public:
-            uint8_t id() const override { return 0; };
+            uint8_t id() const override { return 0; }
             void invoke(Service::Reader& reader) override
             {
                 const auto data = reader.data();
                 const auto serviceId = static_cast<uint8_t>(data.at(1));
                 const auto functionOrStreamId = static_cast<uint8_t>(data.at(2));
                 server().error(LrpcMetaError::UnknownService, serviceId, functionOrStreamId);
-            };
+            }
         };
 
     public:

--- a/src/lrpc/resources/cpp/Service.hpp
+++ b/src/lrpc/resources/cpp/Service.hpp
@@ -68,7 +68,7 @@ namespace lrpc
         void linkServer(IServer& server) { linkedServer = &server; }
 
     protected:
-        IServer& server() const { return *linkedServer; };
+        IServer& server() const { return *linkedServer; }
 
         void requestStop(const uint8_t streamId) const { server().transmit(id(), streamId); }
 

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -105,16 +105,40 @@ TEST(TestEtlRwExtensions, array_out_param_type)
 }
 
 template <typename T>
-class ArithmeticRwTest : public ::testing::Test
+class TestEtlRwExtArithTypes : public ::testing::Test
 {
 };
 
 using ArithmeticTypes =
     ::testing::Types<bool, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double>;
 
-TYPED_TEST_SUITE(ArithmeticRwTest, ArithmeticTypes);
+struct ArithmeticTypeNames
+{
+    template <typename T>
+    static std::string GetName(int /* index */)
+    {
+        static_assert(sizeof(T) == 0, "unknown type in ArithmeticTypes");
+        return "";
+    }
+};
 
-TYPED_TEST(ArithmeticRwTest, write)
+// clang-format off
+template <> std::string ArithmeticTypeNames::GetName<bool>(int)     { return "bool"; }
+template <> std::string ArithmeticTypeNames::GetName<uint8_t>(int)  { return "uint8_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int8_t>(int)   { return "int8_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint16_t>(int) { return "uint16_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int16_t>(int)  { return "int16_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint32_t>(int) { return "uint32_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int32_t>(int)  { return "int32_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint64_t>(int) { return "uint64_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int64_t>(int)  { return "int64_t"; }
+template <> std::string ArithmeticTypeNames::GetName<float>(int)    { return "float"; }
+template <> std::string ArithmeticTypeNames::GetName<double>(int)   { return "double"; }
+// clang-format on
+
+TYPED_TEST_SUITE(TestEtlRwExtArithTypes, ArithmeticTypes, ArithmeticTypeNames);
+
+TYPED_TEST(TestEtlRwExtArithTypes, write)
 {
     etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
     etl::byte_stream_writer writer(storage, etl::endian::little);
@@ -122,7 +146,7 @@ TYPED_TEST(ArithmeticRwTest, write)
     EXPECT_EQ(sizeof(TypeParam), writer.used_data().size());
 }
 
-TYPED_TEST(ArithmeticRwTest, read)
+TYPED_TEST(TestEtlRwExtArithTypes, read)
 {
     etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
     etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
@@ -130,7 +154,7 @@ TYPED_TEST(ArithmeticRwTest, read)
     EXPECT_EQ(0U, reader.available_bytes());
 }
 
-TYPED_TEST(ArithmeticRwTest, roundTrip)
+TYPED_TEST(TestEtlRwExtArithTypes, roundTrip)
 {
     const TypeParam value = static_cast<TypeParam>(42);
     etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
@@ -291,7 +315,7 @@ TEST(TestEtlRwExtensions, readArrayToInsufficientStorage)
     etl::vector<uint8_t, 10> storage{0x00, 0x01, 0x02, 0xAB};
     etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
 
-    // Read of array size 3 is requested, but storage is only 2
+    // Read of array size 3 is requested, but destination array has capacity 2
     lrpc::array<uint8_t, 2> dest{0xFF, 0xFF};
     lrpc::read_unchecked<lrpc::tags::array_n<uint8_t>>(reader, dest, 3);
     EXPECT_EQ(0x00, dest.at(0));
@@ -337,7 +361,7 @@ TEST(TestEtlRwExtensions, readArrayOfFixedSizeStringToInsufficientStorage)
     etl::vector<char, 10> storage{'t', '1', '\0', 't', '2', '\0', 't', '3', '\0', static_cast<char>(0xAB)};
     etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
 
-    // Read of array size 3 is requested, but storage is only 2
+    // Read of array size 3 is requested, but destination array has capacity 2
     lrpc::array<lrpc::string_view, 2> dest{"o1", "o2"};
     lrpc::read_unchecked<lrpc::tags::array_n<lrpc::tags::string_n>>(reader, dest, 3, 2);
     EXPECT_EQ("t1", dest.at(0));
@@ -363,7 +387,7 @@ TEST(TestEtlRwExtensions, readArrayOfAutoStringToInsufficientStorage)
     etl::vector<char, 13> storage{'t', '1', '\0', 't', '2', '\0', 't', '3', '4', '5', '\0', static_cast<char>(0xAB)};
     etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
 
-    // Read of array size 3 is requested, but storage is only 2
+    // Read of array size 3 is requested, but destination array has capacity 2
     lrpc::array<lrpc::string_view, 2> dest{"o1", "o2"};
     lrpc::read_unchecked<lrpc::tags::array_n<lrpc::tags::string_auto>>(reader, dest, 3);
     EXPECT_EQ("t1", dest.at(0));

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -168,6 +168,25 @@ TEST(TestEtlRwExtensions, readAutoString)
     EXPECT_EQ("Test", lrpc::read_unchecked<lrpc::tags::string_auto>(reader));
 }
 
+TEST(TestEtlRwExtensions, readAutoStringEmpty)
+{
+    etl::vector<char, 3> storage{'\0', 'x', 'y'};
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+
+    EXPECT_EQ("", lrpc::read_unchecked<lrpc::tags::string_auto>(reader));
+    EXPECT_EQ(2U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, readAutoStringNoNullTerminator)
+{
+    // No null in stream: all remaining bytes are returned as the string
+    etl::vector<char, 4> storage{'a', 'b', 'c', 'd'};
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+
+    EXPECT_EQ("abcd", lrpc::read_unchecked<lrpc::tags::string_auto>(reader));
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
 TEST(TestEtlRwExtensions, readFixedSizeString)
 {
     etl::vector<char, 10> storage{'T', 'e', 's', 't', '\0', '\0', 'q', '\0'};
@@ -178,6 +197,16 @@ TEST(TestEtlRwExtensions, readFixedSizeString)
     EXPECT_EQ("Test", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 4));
     reader.restart();
     EXPECT_EQ("Test", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 5));
+    EXPECT_EQ("q", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 1));
+}
+
+TEST(TestEtlRwExtensions, readFixedSizeStringEmpty)
+{
+    // Slot starts with '\0': returns empty string, skips full slot
+    etl::vector<char, 6> storage{'\0', '\0', '\0', '\0', 'q', '\0'};
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+
+    EXPECT_EQ("", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 3));
     EXPECT_EQ("q", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 1));
 }
 
@@ -377,6 +406,16 @@ TEST(TestEtlRwExtensions, readBytearray)
     EXPECT_EQ(0x03, bytearray.at(2));
 }
 
+TEST(TestEtlRwExtensions, readBytearrayEmpty)
+{
+    etl::vector<uint8_t, 3> storage{0x00, 0xAB, 0xCD};
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+
+    const auto ba = lrpc::read_unchecked<lrpc::tags::bytearray_auto>(reader);
+    EXPECT_EQ(0U, ba.size());
+    EXPECT_EQ(lrpc::byte{0xAB}, lrpc::read_unchecked<lrpc::byte>(reader));
+}
+
 TEST(TestEtlRwExtensions, readEtlByte)
 {
     etl::vector<uint8_t, 4> storage{0x11, 0xAB};
@@ -465,6 +504,21 @@ TEST(TestEtlRwExtensions, writeFixedSizeStringOverflow)
     EXPECT_EQ('\0', written.at(4));
 }
 
+TEST(TestEtlRwExtensions, writeFixedSizeStringEmpty)
+{
+    lrpc::array<uint8_t, 10> storage;
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+
+    lrpc::write_unchecked<lrpc::tags::string_n>(writer, "", 3);
+
+    const auto written = writer.used_data();
+    ASSERT_EQ(4, written.size());
+    EXPECT_EQ('\0', written.at(0));
+    EXPECT_EQ('\0', written.at(1));
+    EXPECT_EQ('\0', written.at(2));
+    EXPECT_EQ('\0', written.at(3));
+}
+
 TEST(TestEtlRwExtensions, writeAutoString)
 {
     lrpc::array<uint8_t, 10> storage;
@@ -482,6 +536,18 @@ TEST(TestEtlRwExtensions, writeAutoString)
     EXPECT_EQ('T', written.at(3));
     EXPECT_EQ('2', written.at(4));
     EXPECT_EQ('\0', written.at(5));
+}
+
+TEST(TestEtlRwExtensions, writeAutoStringEmpty)
+{
+    lrpc::array<uint8_t, 10> storage;
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+
+    lrpc::write_unchecked<lrpc::tags::string_auto>(writer, "");
+
+    const auto written = writer.used_data();
+    ASSERT_EQ(1, written.size());
+    EXPECT_EQ('\0', written.at(0));
 }
 
 TEST(TestEtlRwExtensions, writeByteArray)

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "generated/core/lrpccore/EtlRwExtensions.hpp"
+#include "generated/core/lrpccore/LrpcByteTypes.hpp"
 #include "generated/core/lrpccore/LrpcTypes.hpp"
 #if (__cplusplus >= 201703L)
 // For std::byte
@@ -64,7 +65,6 @@ TEST(TestEtlRwExtensions, optional_pr_type)
                               lrpc::optional_pr_type<lrpc::optional<lrpc::tags::string_auto>>::type>::value));
     EXPECT_TRUE((std::is_same<lrpc::optional<lrpc::string_view>,
                               lrpc::optional_pr_type<lrpc::optional<lrpc::tags::string_n>>::type>::value));
-    // NOLINTNEXTLINE(misc-include-cleaner)
     EXPECT_TRUE((std::is_same<lrpc::optional<lrpc::bytearray>,
                               lrpc::optional_pr_type<lrpc::optional<lrpc::tags::bytearray_auto>>::type>::value));
 }
@@ -104,16 +104,47 @@ TEST(TestEtlRwExtensions, array_out_param_type)
                       lrpc::array_outparam_type<lrpc::tags::array_n<lrpc::tags::bytearray_auto>>::type>::value));
 }
 
-TEST(TestEtlRwExtensions, readArithmetic)
+template <typename T>
+class ArithmeticRwTest : public ::testing::Test
 {
-    etl::vector<uint8_t, 10> storage{0x00, 0x01, 0x02, 0x03, 0x04, 0x79, 0xE9, 0xF6, 0x42};
-    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+};
 
-    EXPECT_FALSE(lrpc::read_unchecked<bool>(reader));
-    EXPECT_TRUE(lrpc::read_unchecked<bool>(reader));
-    EXPECT_EQ(0x02, lrpc::read_unchecked<uint8_t>(reader));
-    EXPECT_EQ(0x0403, lrpc::read_unchecked<uint16_t>(reader));
-    EXPECT_FLOAT_EQ(123.456F, lrpc::read_unchecked<float>(reader));
+using ArithmeticTypes = ::testing::Types<
+    bool,
+    uint8_t, int8_t,
+    uint16_t, int16_t,
+    uint32_t, int32_t,
+    uint64_t, int64_t,
+    float, double>;
+
+TYPED_TEST_SUITE(ArithmeticRwTest, ArithmeticTypes);
+
+TYPED_TEST(ArithmeticRwTest, write)
+{
+    etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<TypeParam>(writer, TypeParam{1});
+    EXPECT_EQ(sizeof(TypeParam), writer.used_data().size());
+}
+
+TYPED_TEST(ArithmeticRwTest, read)
+{
+    etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    EXPECT_EQ(TypeParam{0}, lrpc::read_unchecked<TypeParam>(reader));
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TYPED_TEST(ArithmeticRwTest, roundTrip)
+{
+    const TypeParam value = static_cast<TypeParam>(42);
+    etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<TypeParam>(writer, value);
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    EXPECT_EQ(value, lrpc::read_unchecked<TypeParam>(reader));
+    EXPECT_EQ(0U, reader.available_bytes());
 }
 
 TEST(TestEtlRwExtensions, readEnum)
@@ -366,30 +397,6 @@ TEST(TestEtlRwExtensions, readStdByte)
 }
 #endif
 
-TEST(TestEtlRwExtensions, writeArithmetic)
-{
-    lrpc::array<uint8_t, 10> storage;
-    etl::byte_stream_writer writer(storage, etl::endian::little);
-
-    lrpc::write_unchecked<bool>(writer, false);
-    lrpc::write_unchecked<bool>(writer, true);
-    lrpc::write_unchecked<uint8_t>(writer, 0x02);
-    lrpc::write_unchecked<uint16_t>(writer, 0x0403);
-    lrpc::write_unchecked<float>(writer, 123.456F);
-
-    const auto written = writer.used_data();
-    ASSERT_EQ(9, written.size());
-    EXPECT_EQ(0x00, static_cast<uint8_t>(written.at(0)));
-    EXPECT_EQ(0x01, static_cast<uint8_t>(written.at(1)));
-    EXPECT_EQ(0x02, static_cast<uint8_t>(written.at(2)));
-    EXPECT_EQ(0x03, static_cast<uint8_t>(written.at(3)));
-    EXPECT_EQ(0x04, static_cast<uint8_t>(written.at(4)));
-    EXPECT_EQ(0x79, static_cast<uint8_t>(written.at(5)));
-    EXPECT_EQ(0xE9, static_cast<uint8_t>(written.at(6)));
-    EXPECT_EQ(0xF6, static_cast<uint8_t>(written.at(7)));
-    EXPECT_EQ(0x42, static_cast<uint8_t>(written.at(8)));
-}
-
 TEST(TestEtlRwExtensions, writeEnum)
 {
     enum class Dummy : uint8_t
@@ -482,7 +489,6 @@ TEST(TestEtlRwExtensions, writeByteArray)
     lrpc::array<uint8_t, 10> storage;
     etl::byte_stream_writer writer(storage, etl::endian::little);
 
-    // NOLINTNEXTLINE(misc-include-cleaner)
     const lrpc::array<lrpc::byte, 3> a0{0x11, 0x12, 0x13};
     const lrpc::array<lrpc::byte, 2> a1{0x14, 0x15};
     lrpc::write_unchecked<lrpc::tags::bytearray_auto>(writer, a0);
@@ -762,3 +768,144 @@ TEST(TestEtlRwExtensions, writeStdByte)
     EXPECT_EQ(0x56, written.at(1));
 }
 #endif
+
+TEST(TestEtlRwExtensions, roundTripEnum)
+{
+    enum class Color : uint8_t
+    {
+        Red = 0x01,
+        Green = 0x02,
+        Blue = 0x03
+    };
+
+    etl::vector<uint8_t, 3> storage(3);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<Color>(writer, Color::Red);
+    lrpc::write_unchecked<Color>(writer, Color::Green);
+    lrpc::write_unchecked<Color>(writer, Color::Blue);
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    EXPECT_EQ(Color::Red, lrpc::read_unchecked<Color>(reader));
+    EXPECT_EQ(Color::Green, lrpc::read_unchecked<Color>(reader));
+    EXPECT_EQ(Color::Blue, lrpc::read_unchecked<Color>(reader));
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripAutoString)
+{
+    // "hello" + null = 6 bytes, "" + null = 1 byte
+    etl::vector<uint8_t, 7> storage(7);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<lrpc::tags::string_auto>(writer, "hello");
+    lrpc::write_unchecked<lrpc::tags::string_auto>(writer, "");
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    EXPECT_EQ("hello", lrpc::read_unchecked<lrpc::tags::string_auto>(reader));
+    EXPECT_EQ("", lrpc::read_unchecked<lrpc::tags::string_auto>(reader));
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripFixedSizeString)
+{
+    // slot size 4: each element occupies exactly 5 bytes (definitionStringSize + 1)
+    // three cases: value shorter than slot, equal, longer (truncated)
+    etl::vector<uint8_t, 15> storage(15);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<lrpc::tags::string_n>(writer, "hi", 4);
+    lrpc::write_unchecked<lrpc::tags::string_n>(writer, "abcd", 4);
+    lrpc::write_unchecked<lrpc::tags::string_n>(writer, "toolong", 4);
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    EXPECT_EQ("hi", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 4));
+    EXPECT_EQ("abcd", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 4));
+    EXPECT_EQ("tool", lrpc::read_unchecked<lrpc::tags::string_n>(reader, 4));
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripBytearray)
+{
+    const lrpc::array<lrpc::byte, 3> ba{0x11, 0x22, 0x33};
+    // ba: 1 size byte + 3 data = 4 bytes; empty: 1 size byte = 1 byte
+    etl::vector<uint8_t, 5> storage(5);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<lrpc::tags::bytearray_auto>(writer, ba);
+    lrpc::write_unchecked<lrpc::tags::bytearray_auto>(writer, {});
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    const auto result = lrpc::read_unchecked<lrpc::tags::bytearray_auto>(reader);
+    ASSERT_EQ(3U, result.size());
+    EXPECT_EQ(0x11, result.at(0));
+    EXPECT_EQ(0x22, result.at(1));
+    EXPECT_EQ(0x33, result.at(2));
+    const auto empty = lrpc::read_unchecked<lrpc::tags::bytearray_auto>(reader);
+    EXPECT_EQ(0U, empty.size());
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripOptional)
+{
+    // absent: 1 byte; present uint16_t: 1 + 2 = 3 bytes
+    etl::vector<uint8_t, 4> storage(4);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    lrpc::write_unchecked<lrpc::optional<uint16_t>>(writer, {});
+    lrpc::write_unchecked<lrpc::optional<uint16_t>>(writer, 0x1234U);
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    const auto o1 = lrpc::read_unchecked<lrpc::optional<uint16_t>>(reader);
+    EXPECT_FALSE(o1.has_value());
+    const auto o2 = lrpc::read_unchecked<lrpc::optional<uint16_t>>(reader);
+    ASSERT_TRUE(o2.has_value());
+    EXPECT_EQ(0x1234U, o2.value());
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripOptionalFixedSizeString)
+{
+    // absent: 1 byte; present "hi" in slot 3: 1 + 4 = 5 bytes
+    etl::vector<uint8_t, 6> storage(6);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    const lrpc::optional<lrpc::string_view> absent{};
+    const lrpc::optional<lrpc::string_view> present{"hi"};
+    lrpc::write_unchecked<lrpc::optional<lrpc::tags::string_n>>(writer, absent, 3);
+    lrpc::write_unchecked<lrpc::optional<lrpc::tags::string_n>>(writer, present, 3);
+
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    const auto o1 = lrpc::read_unchecked<lrpc::optional<lrpc::tags::string_n>>(reader, 3);
+    EXPECT_FALSE(o1.has_value());
+    const auto o2 = lrpc::read_unchecked<lrpc::optional<lrpc::tags::string_n>>(reader, 3);
+    ASSERT_TRUE(o2.has_value());
+    EXPECT_EQ("hi", o2.value());
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripArray)
+{
+    etl::vector<uint8_t, 3> storage(3);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    const lrpc::array<uint8_t, 3> values{0x0A, 0x0B, 0x0C};
+    lrpc::write_unchecked<lrpc::tags::array_n<uint8_t>>(writer, values, 3);
+
+    lrpc::array<uint8_t, 3> dest;
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    lrpc::read_unchecked<lrpc::tags::array_n<uint8_t>>(reader, dest, 3);
+    EXPECT_EQ(0x0A, dest.at(0));
+    EXPECT_EQ(0x0B, dest.at(1));
+    EXPECT_EQ(0x0C, dest.at(2));
+    EXPECT_EQ(0U, reader.available_bytes());
+}
+
+TEST(TestEtlRwExtensions, roundTripArrayOfFixedSizeString)
+{
+    // 2 elements, slot size 3: each uses 4 bytes, total 8 bytes
+    etl::vector<uint8_t, 8> storage(8);
+    etl::byte_stream_writer writer(storage, etl::endian::little);
+    const lrpc::array<lrpc::string_view, 2> values{"ab", "cd"};
+    lrpc::write_unchecked<lrpc::tags::array_n<lrpc::tags::string_n>>(writer, values, 2, 3);
+
+    lrpc::array<lrpc::string_view, 2> dest{"", ""};
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+    lrpc::read_unchecked<lrpc::tags::array_n<lrpc::tags::string_n>>(reader, dest, 2, 3);
+    EXPECT_EQ("ab", dest.at(0));
+    EXPECT_EQ("cd", dest.at(1));
+    EXPECT_EQ(0U, reader.available_bytes());
+}

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -244,6 +244,26 @@ TEST(TestEtlRwExtensions, readArrayToInsufficientStorage)
     EXPECT_EQ(0xAB, lrpc::read_unchecked<uint8_t>(reader));
 }
 
+TEST(TestEtlRwExtensions, readArrayOfEnumToInsufficientStorage)
+{
+    enum class Dummy : uint8_t
+    {
+        V1 = 0xAA,
+        V2 = 0xBB,
+        V3 = 0xCC
+    };
+
+    etl::vector<uint8_t, 4> storage{0xAA, 0xBB, 0xCC, 0xAB};
+    etl::byte_stream_reader reader(storage.begin(), storage.end(), etl::endian::little);
+
+    // Read of array size 3 is requested, but destination array has capacity 2
+    lrpc::array<Dummy, 2> dest{Dummy::V1, Dummy::V1};
+    lrpc::read_unchecked<lrpc::tags::array_n<Dummy>>(reader, dest, 3);
+    EXPECT_EQ(Dummy::V1, dest.at(0));
+    EXPECT_EQ(Dummy::V2, dest.at(1));
+    EXPECT_EQ(0xAB, lrpc::read_unchecked<uint8_t>(reader));
+}
+
 TEST(TestEtlRwExtensions, readArrayOfFixedSizeString)
 {
     etl::vector<char, 10> storage{'t', '1', '\0', 't', '2', '\0', 't', '3', '\0'};

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -157,7 +157,7 @@ TYPED_TEST(TestEtlRwExtArithTypes, read)
 
 TYPED_TEST(TestEtlRwExtArithTypes, roundTrip)
 {
-    const TypeParam value = static_cast<TypeParam>(42);
+    const auto value = static_cast<TypeParam>(42);
     etl::vector<uint8_t, sizeof(TypeParam)> storage(sizeof(TypeParam));
     etl::byte_stream_writer writer(storage, etl::endian::little);
     lrpc::write_unchecked<TypeParam>(writer, value);

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -16,6 +16,7 @@
 
 #include <etl/byte.h>
 #include <etl/byte_stream.h>
+#include <etl/endianness.h>
 #include <etl/string.h>
 #include <etl/vector.h>
 
@@ -123,17 +124,17 @@ struct ArithmeticTypeNames
 };
 
 // clang-format off
-template <> std::string ArithmeticTypeNames::GetName<bool>(int)     { return "bool"; }
-template <> std::string ArithmeticTypeNames::GetName<uint8_t>(int)  { return "uint8_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int8_t>(int)   { return "int8_t"; }
-template <> std::string ArithmeticTypeNames::GetName<uint16_t>(int) { return "uint16_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int16_t>(int)  { return "int16_t"; }
-template <> std::string ArithmeticTypeNames::GetName<uint32_t>(int) { return "uint32_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int32_t>(int)  { return "int32_t"; }
-template <> std::string ArithmeticTypeNames::GetName<uint64_t>(int) { return "uint64_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int64_t>(int)  { return "int64_t"; }
-template <> std::string ArithmeticTypeNames::GetName<float>(int)    { return "float"; }
-template <> std::string ArithmeticTypeNames::GetName<double>(int)   { return "double"; }
+template <> std::string ArithmeticTypeNames::GetName<bool>(int /* index */)     { return "bool"; }
+template <> std::string ArithmeticTypeNames::GetName<uint8_t>(int /* index */)  { return "uint8_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int8_t>(int /* index */)   { return "int8_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint16_t>(int /* index */) { return "uint16_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int16_t>(int /* index */)  { return "int16_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint32_t>(int /* index */) { return "uint32_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int32_t>(int /* index */)  { return "int32_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint64_t>(int /* index */) { return "uint64_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int64_t>(int /* index */)  { return "int64_t"; }
+template <> std::string ArithmeticTypeNames::GetName<float>(int /* index */)    { return "float"; }
+template <> std::string ArithmeticTypeNames::GetName<double>(int /* index */)   { return "double"; }
 // clang-format on
 
 TYPED_TEST_SUITE(TestEtlRwExtArithTypes, ArithmeticTypes, ArithmeticTypeNames);

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -116,7 +116,7 @@ using ArithmeticTypes =
 struct ArithmeticTypeNames
 {
     template <typename T>
-    static std::string GetName(int /* index */)
+    static std::string GetName(int64_t /* index */)
     {
         static_assert(sizeof(T) == 0, "unknown type in ArithmeticTypes");
         return "";
@@ -124,17 +124,17 @@ struct ArithmeticTypeNames
 };
 
 // clang-format off
-template <> std::string ArithmeticTypeNames::GetName<bool>(int /* index */)     { return "bool"; }
-template <> std::string ArithmeticTypeNames::GetName<uint8_t>(int /* index */)  { return "uint8_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int8_t>(int /* index */)   { return "int8_t"; }
-template <> std::string ArithmeticTypeNames::GetName<uint16_t>(int /* index */) { return "uint16_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int16_t>(int /* index */)  { return "int16_t"; }
-template <> std::string ArithmeticTypeNames::GetName<uint32_t>(int /* index */) { return "uint32_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int32_t>(int /* index */)  { return "int32_t"; }
-template <> std::string ArithmeticTypeNames::GetName<uint64_t>(int /* index */) { return "uint64_t"; }
-template <> std::string ArithmeticTypeNames::GetName<int64_t>(int /* index */)  { return "int64_t"; }
-template <> std::string ArithmeticTypeNames::GetName<float>(int /* index */)    { return "float"; }
-template <> std::string ArithmeticTypeNames::GetName<double>(int /* index */)   { return "double"; }
+template <> std::string ArithmeticTypeNames::GetName<bool>(int64_t /* index */)     { return "bool"; }
+template <> std::string ArithmeticTypeNames::GetName<uint8_t>(int64_t /* index */)  { return "uint8_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int8_t>(int64_t /* index */)   { return "int8_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint16_t>(int64_t /* index */) { return "uint16_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int16_t>(int64_t /* index */)  { return "int16_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint32_t>(int64_t /* index */) { return "uint32_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int32_t>(int64_t /* index */)  { return "int32_t"; }
+template <> std::string ArithmeticTypeNames::GetName<uint64_t>(int64_t /* index */) { return "uint64_t"; }
+template <> std::string ArithmeticTypeNames::GetName<int64_t>(int64_t /* index */)  { return "int64_t"; }
+template <> std::string ArithmeticTypeNames::GetName<float>(int64_t /* index */)    { return "float"; }
+template <> std::string ArithmeticTypeNames::GetName<double>(int64_t /* index */)   { return "double"; }
 // clang-format on
 
 TYPED_TEST_SUITE(TestEtlRwExtArithTypes, ArithmeticTypes, ArithmeticTypeNames);

--- a/tests/cpp/TestEtlRwExtensions.cpp
+++ b/tests/cpp/TestEtlRwExtensions.cpp
@@ -109,13 +109,8 @@ class ArithmeticRwTest : public ::testing::Test
 {
 };
 
-using ArithmeticTypes = ::testing::Types<
-    bool,
-    uint8_t, int8_t,
-    uint16_t, int16_t,
-    uint32_t, int32_t,
-    uint64_t, int64_t,
-    float, double>;
+using ArithmeticTypes =
+    ::testing::Types<bool, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double>;
 
 TYPED_TEST_SUITE(ArithmeticRwTest, ArithmeticTypes);
 


### PR DESCRIPTION
# :sparkle: @coderabbitai

## Description

Fixes issue #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project changelog with an “EtlRwExtensions cleanup” note.
  * Tightened Clang warning coverage.
  * Adjusted code analysis configuration for source vs test paths.
* **Bug Fixes**
  * Improved serialization/deserialization for arrays and string-like payloads, including safer string view construction and more efficient skipping when discarding remaining elements.
  * Corrected fixed-size string padding behavior.
* **Tests**
  * Expanded ETL read/write coverage for empty strings, fixed-size string slots, byte arrays, and many end-of-file round-trip scenarios (including enums, optionals, and nested arrays).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Type

- [ ] feature
- [ ] bugfix
- [ ] doc
- [ ] removal
- [x] misc
